### PR TITLE
Leverage testing to ensure that generated net_skeleton files are in sync

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -5,7 +5,13 @@ SOURCES = skeleton.c $(FR)/frozen.c http.c sha1.c util.c json-rpc.c
 all: ../net_skeleton.c ../net_skeleton.h
 
 ../net_skeleton.h: Makefile $(HEADERS)
-	cat $(HEADERS) > $@
+	$(MAKE) merge_net_skeleton.h >$@
 
 ../net_skeleton.c: Makefile $(SOURCES)
-	(echo '#include "net_skeleton.h"'; (cat $(SOURCES) | sed '/^#include "/d')) > $@
+	$(MAKE) merge_net_skeleton.c >$@
+
+merge_net_skeleton.h: Makefile $(HEADERS)
+	@cat $(HEADERS)
+
+merge_net_skeleton.c: Makefile $(SOURCES)
+	@(echo '#include "net_skeleton.h"'; (cat $(SOURCES) | sed '/^#include "/d'))

--- a/net_skeleton.c
+++ b/net_skeleton.c
@@ -1350,9 +1350,7 @@ int json_emit_va(char *s, int s_len, const char *fmt, va_list ap) {
     switch (*fmt) {
       case '[': case ']': case '{': case '}': case ',': case ':':
       case ' ': case '\r': case '\n': case '\t':
-        if (s < end) {
-          *s = *fmt;
-        }
+        if (s < end) *s = *fmt;
         s++;
         break;
       case 'i':
@@ -1394,10 +1392,7 @@ int json_emit_va(char *s, int s_len, const char *fmt, va_list ap) {
     fmt++;
   }
 
-  // Best-effort to 0-terminate generated string
-  if (s < end) {
-    *s = '\0';
-  }
+  if (s < end) *s = '\0';
 
   return s - orig;
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,7 +3,11 @@ PROF = -fprofile-arcs -ftest-coverage -g -O0
 CFLAGS = -W -Wall -I.. -DNS_ENABLE_SSL -pthread $(PROF) $(CFLAGS_EXTRA)
 SOURCES = $(PROG).c ../net_skeleton.c
 
-all: clean $(PROG)
+all: clean ismerged $(PROG)
+
+ismerged:
+	$(MAKE) -C ../modules merge_net_skeleton.c | diff ../net_skeleton.c -
+	$(MAKE) -C ../modules merge_net_skeleton.h | diff ../net_skeleton.h -
 
 $(PROG):
 	g++ $(PROG).c -o $(PROG) $(CFLAGS) -lssl && ./$(PROG)


### PR DESCRIPTION
The CI does a good job of letting us know our commit.
This is easier to do than to rely on commit hooks, doesn't require local repos to set hooks, and is part of the tests that can be run locally.
