### PR TITLE
Use __va_copy as fallback fo va_copy and a = b as fallback of the fallback

### DIFF
--- a/modules/json-rpc.c
+++ b/modules/json-rpc.c
@@ -13,7 +13,7 @@ int ns_rpc_reply(struct ns_connection *nc, const char *fmt, ...) {
 
   /* Find out how long the message is, without actually making a message */
   va_start(ap, fmt);
-  __va_copy(ap_copy, ap);
+  va_copy(ap_copy, ap);
   len = json_emit_va(NULL, 0, fmt, ap);
   va_end(ap);
 

--- a/modules/skeleton.c
+++ b/modules/skeleton.c
@@ -143,7 +143,7 @@ int ns_avprintf(char **buf, size_t size, const char *fmt, va_list ap) {
   va_list ap_copy;
   int len;
 
-  __va_copy(ap_copy, ap);
+  va_copy(ap_copy, ap);
   len = vsnprintf(*buf, size, fmt, ap_copy);
   va_end(ap_copy);
 
@@ -156,7 +156,7 @@ int ns_avprintf(char **buf, size_t size, const char *fmt, va_list ap) {
       if (*buf) free(*buf);
       size *= 2;
       if ((*buf = (char *) NS_MALLOC(size)) == NULL) break;
-      __va_copy(ap_copy, ap);
+      va_copy(ap_copy, ap);
       len = vsnprintf(*buf, size, fmt, ap_copy);
       va_end(ap_copy);
     }
@@ -165,7 +165,7 @@ int ns_avprintf(char **buf, size_t size, const char *fmt, va_list ap) {
     if ((*buf = (char *) NS_MALLOC(len + 1)) == NULL) {
       len = -1;
     } else {
-      __va_copy(ap_copy, ap);
+      va_copy(ap_copy, ap);
       len = vsnprintf(*buf, len + 1, fmt, ap_copy);
       va_end(ap_copy);
     }

--- a/modules/skeleton.h
+++ b/modules/skeleton.h
@@ -53,6 +53,14 @@
 #include <time.h>
 #include <signal.h>
 
+#ifndef va_copy
+#ifdef __va_copy
+#define va_copy __va_copy
+#else
+#define va_copy(x,y) (x) = (y)
+#endif
+#endif
+
 #ifdef _WIN32
 #ifdef _MSC_VER
 #pragma comment(lib, "ws2_32.lib")    /* Linking with winsock library */
@@ -70,9 +78,6 @@
 #define STR(x) STRX(x)
 #define __func__ __FILE__ ":" STR(__LINE__)
 #endif
-#ifndef __va_copy
-#define __va_copy(x,y) (x) = (y)
-#endif /* MINGW #defines va_copy */
 #define snprintf _snprintf
 #define vsnprintf _vsnprintf
 #define sleep(x) Sleep((x) * 1000)

--- a/net_skeleton.c
+++ b/net_skeleton.c
@@ -143,7 +143,7 @@ int ns_avprintf(char **buf, size_t size, const char *fmt, va_list ap) {
   va_list ap_copy;
   int len;
 
-  __va_copy(ap_copy, ap);
+  va_copy(ap_copy, ap);
   len = vsnprintf(*buf, size, fmt, ap_copy);
   va_end(ap_copy);
 
@@ -156,7 +156,7 @@ int ns_avprintf(char **buf, size_t size, const char *fmt, va_list ap) {
       if (*buf) free(*buf);
       size *= 2;
       if ((*buf = (char *) NS_MALLOC(size)) == NULL) break;
-      __va_copy(ap_copy, ap);
+      va_copy(ap_copy, ap);
       len = vsnprintf(*buf, size, fmt, ap_copy);
       va_end(ap_copy);
     }
@@ -165,7 +165,7 @@ int ns_avprintf(char **buf, size_t size, const char *fmt, va_list ap) {
     if ((*buf = (char *) NS_MALLOC(len + 1)) == NULL) {
       len = -1;
     } else {
-      __va_copy(ap_copy, ap);
+      va_copy(ap_copy, ap);
       len = vsnprintf(*buf, len + 1, fmt, ap_copy);
       va_end(ap_copy);
     }
@@ -2045,7 +2045,7 @@ int ns_rpc_reply(struct ns_connection *nc, const char *fmt, ...) {
 
   /* Find out how long the message is, without actually making a message */
   va_start(ap, fmt);
-  __va_copy(ap_copy, ap);
+  va_copy(ap_copy, ap);
   len = json_emit_va(NULL, 0, fmt, ap);
   va_end(ap);
 

--- a/net_skeleton.h
+++ b/net_skeleton.h
@@ -53,6 +53,14 @@
 #include <time.h>
 #include <signal.h>
 
+#ifndef va_copy
+#ifdef __va_copy
+#define va_copy __va_copy
+#else
+#define va_copy(x,y) (x) = (y)
+#endif
+#endif /* MINGW #defines va_copy */
+
 #ifdef _WIN32
 #ifdef _MSC_VER
 #pragma comment(lib, "ws2_32.lib")    /* Linking with winsock library */
@@ -70,8 +78,8 @@
 #define STR(x) STRX(x)
 #define __func__ __FILE__ ":" STR(__LINE__)
 #endif
-#ifndef __va_copy
-#define __va_copy(x,y) (x) = (y)
+#ifndef va_copy
+#define va_copy(x,y) (x) = (y)
 #endif /* MINGW #defines va_copy */
 #define snprintf _snprintf
 #define vsnprintf _vsnprintf


### PR DESCRIPTION
This is needed because clang in c89 mode implements __va_copy
(it was in draft version of the spec) but forbids assignments of __builtin_va_list).

What do you think?

(I'm also looking at what the CI says, too lazy to spawn a linux VM)
