### PR TITLE
Hide /net_skeleton.[ch] from git diff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+net_skeleton.c -diff
+net_skeleton.h -diff


### PR DESCRIPTION
Hide amalgamated files by treating them as binary files.
The users will still see that there are diffs but they won't be distracted
by duplicated diffs in every `git diff` output.

I got the idea from:
http://blog.andrewray.me/dealing-with-compiled-files-in-git/

It's a first step towards improving the handling of amalgamated 
and other kinds of generated files.
