### PR TITLE
Hide /net_skeleton.[ch] from git diff

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,12 @@
 = Networking library for C/C++
 
+:buildstatus-uri: https://www.codeship.io/projects/72674aa0-1cbd-0132-0050-4a361eed21f8
+:buildstatus-badge: https://www.codeship.io/projects/72674aa0-1cbd-0132-0050-4a361eed21f8/status?branch=mastef::env-github[]
+
+ifdef::env-github[]
+image:{buildstatus-badge}[Build Status,link={buildstatus-uri}]
+endif::[]
+
 Net Skeleton is a networking library written in C.
 It provides easy to use event-driven interface that allows to implement
 network protocols or scalable network applications  with little effort.


### PR DESCRIPTION
Hide amalgamated files by treating them as binary files.
The users will still see that there are diffs but they won't be distracted
by duplicated diffs in every `git diff` output.
