### PR TITLE
Reuse of the data type "sig_atomic_t"

### DIFF
--- a/examples/netcat/nc.c
+++ b/examples/netcat/nc.c
@@ -20,7 +20,7 @@
 
 #include "net_skeleton.h"
 
-static int s_received_signal = 0;
+static sig_atomic_t s_received_signal = 0;
 
 static void signal_handler(int sig_num) {
   signal(sig_num, signal_handler);

--- a/examples/websocket_chat/websocket_chat.c
+++ b/examples/websocket_chat/websocket_chat.c
@@ -5,7 +5,7 @@
 
 #include "net_skeleton.h"
 
-static int s_signal_received = 0;
+static sig_atomic_t s_signal_received = 0;
 static const char *s_http_port = "8000";
 static struct ns_serve_http_opts s_http_server_opts = { "." };
 


### PR DESCRIPTION
Two variables are used in signal handler implementations for this software.
Would you like to change their data type to [sig_atomic_t](http://en.cppreference.com/w/c/program/sig_atomic_t) to improve software portability?
