### PR TITLE
Fix url decode

### DIFF
--- a/fossa.c
+++ b/fossa.c
@@ -2331,13 +2331,17 @@ static int ns_url_decode(const char *src, int src_len, char *dst,
 #define HEXTOI(x) (isdigit(x) ? x - '0' : x - 'W')
 
   for (i = j = 0; i < src_len && j < dst_len - 1; i++, j++) {
-    if (src[i] == '%' && i < src_len - 2 &&
-        isxdigit(* (const unsigned char *) (src + i + 1)) &&
-        isxdigit(* (const unsigned char *) (src + i + 2))) {
-      a = tolower(* (const unsigned char *) (src + i + 1));
-      b = tolower(* (const unsigned char *) (src + i + 2));
-      dst[j] = (char) ((HEXTOI(a) << 4) | HEXTOI(b));
-      i += 2;
+    if (src[i] == '%') {
+      if (i < src_len - 2 &&
+          isxdigit(* (const unsigned char *) (src + i + 1)) &&
+          isxdigit(* (const unsigned char *) (src + i + 2))) {
+        a = tolower(* (const unsigned char *) (src + i + 1));
+        b = tolower(* (const unsigned char *) (src + i + 2));
+        dst[j] = (char) ((HEXTOI(a) << 4) | HEXTOI(b));
+        i += 2;
+      } else {
+        return -1;
+      }
     } else if (is_form_url_encoded && src[i] == '+') {
       dst[j] = ' ';
     } else {

--- a/modules/http.c
+++ b/modules/http.c
@@ -610,13 +610,17 @@ static int ns_url_decode(const char *src, int src_len, char *dst,
 #define HEXTOI(x) (isdigit(x) ? x - '0' : x - 'W')
 
   for (i = j = 0; i < src_len && j < dst_len - 1; i++, j++) {
-    if (src[i] == '%' && i < src_len - 2 &&
-        isxdigit(* (const unsigned char *) (src + i + 1)) &&
-        isxdigit(* (const unsigned char *) (src + i + 2))) {
-      a = tolower(* (const unsigned char *) (src + i + 1));
-      b = tolower(* (const unsigned char *) (src + i + 2));
-      dst[j] = (char) ((HEXTOI(a) << 4) | HEXTOI(b));
-      i += 2;
+    if (src[i] == '%') {
+      if (i < src_len - 2 &&
+          isxdigit(* (const unsigned char *) (src + i + 1)) &&
+          isxdigit(* (const unsigned char *) (src + i + 2))) {
+        a = tolower(* (const unsigned char *) (src + i + 1));
+        b = tolower(* (const unsigned char *) (src + i + 2));
+        dst[j] = (char) ((HEXTOI(a) << 4) | HEXTOI(b));
+        i += 2;
+      } else {
+        return -1;
+      }
     } else if (is_form_url_encoded && src[i] == '+') {
       dst[j] = ' ';
     } else {

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -405,6 +405,13 @@ static const char *test_get_http_var(void) {
   ASSERT(ns_get_http_var(&body, "key", buf, 0) == -2);
   ASSERT(ns_get_http_var(&body, NULL, buf, sizeof(buf)) == -1);
 
+  body.p = "key=broken%2";
+  body.len = strlen(body.p);
+  ASSERT(ns_get_http_var(&body, "key", buf, sizeof(buf)) < 0);
+
+  body.p = "key=broken%2x";
+  body.len = strlen(body.p);
+  ASSERT(ns_get_http_var(&body, "key", buf, sizeof(buf)) < 0);
   return NULL;
 }
 


### PR DESCRIPTION
Scanning through the code coverage I noticed an unexcercised path in the handling of ns_uri_decode errors that made me notice that the current implementation might be to lax. Do you think ns_uri_decode should fail on invalid escapes (as shown in the tests added in b45ba51, test failure is intentional) ?
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/cesanta/net_skeleton/pull/44%23issuecomment-61398197%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cesanta/net_skeleton/pull/44%23issuecomment-61398197%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Yeah%20I%20think%20we%20should%20fail%20on%20invalid%20escapes.%22%2C%20%22created_at%22%3A%20%222014-11-02T09%3A32%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/601816%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cpq%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cesanta/net_skeleton/pull/44#issuecomment-61398197'>General Comment</a></b>
- <a href='https://github.com/cpq'><img border=0 src='https://avatars.githubusercontent.com/u/601816?v=2' height=16 width=16'></a> Yeah I think we should fail on invalid escapes.

<a href='https://www.codereviewhub.com/cesanta/net_skeleton/pull/44?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cesanta/net_skeleton/pull/44?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cesanta/net_skeleton/pull/44'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
