### PR TITLE
For large HTTP file downloads, never copy the whole file into IO buffer

### DIFF
--- a/modules/http.h
+++ b/modules/http.h
@@ -13,6 +13,7 @@ extern "C" {
 #define NS_MAX_HTTP_HEADERS 40
 #define NS_MAX_HTTP_REQUEST_SIZE 8192
 #define NS_MAX_PATH 1024
+#define NS_MAX_HTTP_SEND_IOBUF 4096
 
 struct http_message {
   struct ns_str message;    /* Whole message: request line + headers + body */

--- a/modules/skeleton.c
+++ b/modules/skeleton.c
@@ -848,7 +848,8 @@ time_t ns_mgr_poll(struct ns_mgr *mgr, int milli) {
         nc->last_io_time = current_time;
         if (nc->flags & NSF_CONNECTING) {
           ns_read_from_socket(nc);
-        } else if (!(nc->flags & NSF_BUFFER_BUT_DONT_SEND)) {
+        } else if (!(nc->flags & NSF_BUFFER_BUT_DONT_SEND) &&
+                   !(nc->flags & NSF_CLOSE_IMMEDIATELY)) {
           ns_write_to_socket(nc);
         }
       }

--- a/net_skeleton.c
+++ b/net_skeleton.c
@@ -848,7 +848,8 @@ time_t ns_mgr_poll(struct ns_mgr *mgr, int milli) {
         nc->last_io_time = current_time;
         if (nc->flags & NSF_CONNECTING) {
           ns_read_from_socket(nc);
-        } else if (!(nc->flags & NSF_BUFFER_BUT_DONT_SEND)) {
+        } else if (!(nc->flags & NSF_BUFFER_BUT_DONT_SEND) &&
+                   !(nc->flags & NSF_CLOSE_IMMEDIATELY)) {
           ns_write_to_socket(nc);
         }
       }
@@ -1500,6 +1501,10 @@ int json_emit(char *buf, int buf_len, const char *fmt, ...) {
 #ifndef NS_DISABLE_HTTP_WEBSOCKET
 
 
+struct proto_data_http {
+  FILE *fp;   /* Opened file */
+};
+
 /*
  * Check whether full request is buffered. Return:
  *   -1  if request is malformed
@@ -1772,6 +1777,23 @@ static void ws_handshake(struct ns_connection *nc, const struct ns_str *key) {
             "Sec-WebSocket-Accept: ", b64_sha, "\r\n\r\n");
 }
 
+static void transfer_file_data(struct ns_connection *nc) {
+  struct proto_data_http *dp = (struct proto_data_http *) nc->proto_data;
+  struct iobuf *io = &nc->send_iobuf;
+  char buf[NS_MAX_HTTP_SEND_IOBUF];
+  size_t n;
+
+  if (nc->send_iobuf.len >= NS_MAX_HTTP_SEND_IOBUF) {
+    /* If output buffer is too big, do nothing until it's drained */
+  } else if ((n = fread(buf, 1, sizeof(buf) - io->len, dp->fp)) > 0) {
+    ns_send(nc, buf, n);
+  } else {
+    fclose(dp->fp);
+    free(dp);
+    nc->proto_data = NULL;
+  }
+}
+
 static void http_handler(struct ns_connection *nc, int ev, void *ev_data) {
   struct iobuf *io = &nc->recv_iobuf;
   struct http_message hm;
@@ -1786,6 +1808,10 @@ static void http_handler(struct ns_connection *nc, int ev, void *ev_data) {
       ns_parse_http(io->buf, io->len, &hm) > 0) {
     hm.body.len = io->buf + io->len - hm.body.p;
     nc->handler(nc, nc->listener ? NS_HTTP_REQUEST : NS_HTTP_REPLY, &hm);
+  }
+
+  if (nc->proto_data != NULL) {
+    transfer_file_data(nc);
   }
 
   nc->handler(nc, ev, ev_data);
@@ -1848,22 +1874,25 @@ void ns_send_websocket_handshake(struct ns_connection *nc, const char *uri,
             uri, key, extra_headers == NULL ? "" : extra_headers);
 }
 
+static void send_http_error(struct ns_connection *nc, int code,
+                            const char *reason) {
+  ns_printf(nc, "HTTP/1.1 %d %s\r\nContent-Length: 0\r\n\r\n", code, reason);
+}
+
 void ns_send_http_file(struct ns_connection *nc, const char *path,
                        ns_stat_t *st) {
-  char buf[BUFSIZ];
-  size_t n;
-  FILE *fp;
+  struct proto_data_http *dp;
 
-  if ((fp = fopen(path, "rb")) != NULL) {
+  if ((dp = (struct proto_data_http *) calloc(1, sizeof(*dp))) == NULL) {
+    send_http_error(nc, 500, "Server Error");
+  } else if ((dp->fp = fopen(path, "rb")) == NULL) {
+    free(dp);
+    send_http_error(nc, 500, "Server Error");
+  } else {
     ns_printf(nc, "HTTP/1.1 200 OK\r\n"
               "Content-Length: %lu\r\n\r\n", (unsigned long) st->st_size);
-    while ((n = fread(buf, 1, sizeof(buf), fp)) > 0) {
-      ns_send(nc, buf, n);
-    }
-    fclose(fp);
-  } else {
-    ns_printf(nc, "%s", "HTTP/1.1 500 Server Error\r\n"
-              "Content-Length: 0\r\n\r\n");
+    nc->proto_data = (void *) dp;
+    transfer_file_data(nc);
   }
 }
 

--- a/net_skeleton.h
+++ b/net_skeleton.h
@@ -429,6 +429,7 @@ extern "C" {
 #define NS_MAX_HTTP_HEADERS 40
 #define NS_MAX_HTTP_REQUEST_SIZE 8192
 #define NS_MAX_PATH 1024
+#define NS_MAX_HTTP_SEND_IOBUF 4096
 
 struct http_message {
   struct ns_str message;    /* Whole message: request line + headers + body */


### PR DESCRIPTION
Do file transfer by small chunks.
Saving state in the `nc->proto_data`, which will be the placeholder for more HTTP state, e.g. for CGI-related data.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/mmikulicic%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/52673%3Fv%3D2%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cesanta/net_skeleton/pull/45%23issuecomment-61400945%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222014-11-02T10%3A33%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/52673%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mmikulicic%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Commit%201260d95602acfd72d81f0a096732cddbfd320800%20modules/http.c%204%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/cesanta/net_skeleton/commit/1260d95602acfd72d81f0a096732cddbfd320800%23commitcomment-8399197%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20looks%20like%20this%20structure%20is%20very%20specific%20to%20the%20transfer_file_data%20function.%5Cr%5Cnproto_data_http%20seems%20a%20too%20generic%20name%2C%20perhaps%20transfer_file_proto_data%20%3F%22%2C%20%22created_at%22%3A%20%222014-11-02T10%3A13%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/52673%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mmikulicic%22%7D%7D%2C%20%7B%22body%22%3A%20%22Very%20soon%20it%27ll%20contain%20%60struct%20ns_connection%20%2Acgi_conn%60%20member%2C%20for%20handling%20CGI%20requests.%5Cr%5CnFor%20serving%20large%20directory%20listings%2C%20we%20may%20add%20%60DIR%20%2A%60%20member.%22%2C%20%22created_at%22%3A%20%222014-11-02T10%3A20%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/601816%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cpq%22%7D%7D%2C%20%7B%22body%22%3A%20%22Will%20all%20those%20fields%20be%20used%20together%20%3F%5Cr%5CnIs%20your%20idea%20to%20just%20have%20one%20single%20struct%20filled%20with%20whatever%20fields%20are%20needed%20by%20the%20HTTP%20handler%20and%20each%20action%20will%20just%20use%20a%20few%20fields%20at%20a%20time%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222014-11-02T10%3A30%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/52673%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mmikulicic%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222014-11-02T10%3A33%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/52673%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mmikulicic%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%2C%20that%27s%20the%20intention.%5Cr%5CnIn%20mongoose%2C%20it%20is%20done%20as%20a%20union%20with%20type%20selector%3A%5Cr%5Cnhttps%3A//github.com/cesanta/mongoose/blob/5.5/mongoose.c%23L1420-L1428%5Cr%5Cn%5Cr%5Cnbut%20I%20think%20having%20it%20as%20a%20flat%20structure%20is%20simpler.%20E.g.%20if%20file%20stream%20is%20non-NULL%2C%20then%20%60proto_data%60%20describes%20opened%20file.%20Otherwise%20if%20cgi%20connection%20is%20non-NULL%2C%20then%20%60proto_data%60%20describes%20opened%20cgi%20connection%20%28a%20socketpair%27s%20end%20to%20the%20CGI%20program%20stdin/stdout%29.%20Etc%20etc.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222014-11-02T10%3A45%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/601816%3Fv%3D2%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cpq%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20modules/http.c%3AL13%20%281260d95%29%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/cesanta/net_skeleton/pull/45%23issuecomment-61400945%22%2C%20%22https%3A//github.com/cesanta/net_skeleton/commit/1260d95602acfd72d81f0a096732cddbfd320800%23commitcomment-8399197%22%2C%20%22https%3A//github.com/cesanta/net_skeleton/commit/1260d95602acfd72d81f0a096732cddbfd320800%23commitcomment-8399211%22%2C%20%22https%3A//github.com/cesanta/net_skeleton/commit/1260d95602acfd72d81f0a096732cddbfd320800%23commitcomment-8399232%22%2C%20%22https%3A//github.com/cesanta/net_skeleton/commit/1260d95602acfd72d81f0a096732cddbfd320800%23commitcomment-8399239%22%2C%20%22https%3A//github.com/cesanta/net_skeleton/commit/1260d95602acfd72d81f0a096732cddbfd320800%23commitcomment-8399255%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/mmikulicic'><img src='https://avatars.githubusercontent.com/u/52673?v=2' width=34 height=34></a>
- [ ] <a href='#crh-comment-Commit 1260d95602acfd72d81f0a096732cddbfd320800 modules/http.c 4 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/cesanta/net_skeleton/commit/1260d95602acfd72d81f0a096732cddbfd320800#commitcomment-8399197'>File: modules/http.c:L13 (1260d95)</a></b>
- <a href='https://github.com/mmikulicic'><img border=0 src='https://avatars.githubusercontent.com/u/52673?v=2' height=16 width=16'></a> It looks like this structure is very specific to the transfer_file_data function.
  proto_data_http seems a too generic name, perhaps transfer_file_proto_data ?
- <a href='https://github.com/cpq'><img border=0 src='https://avatars.githubusercontent.com/u/601816?v=2' height=16 width=16'></a> Very soon it'll contain `struct ns_connection *cgi_conn` member, for handling CGI requests.
  For serving large directory listings, we may add `DIR *` member.
- <a href='https://github.com/mmikulicic'><img border=0 src='https://avatars.githubusercontent.com/u/52673?v=2' height=16 width=16'></a> Will all those fields be used together ?
  Is your idea to just have one single struct filled with whatever fields are needed by the HTTP handler and each action will just use a few fields at a time?
- <a href='https://github.com/mmikulicic'><img border=0 src='https://avatars.githubusercontent.com/u/52673?v=2' height=16 width=16'></a> :+1:
- <a href='https://github.com/cpq'><img border=0 src='https://avatars.githubusercontent.com/u/601816?v=2' height=16 width=16'></a> Yeah, that's the intention.
  In mongoose, it is done as a union with type selector:
  https://github.com/cesanta/mongoose/blob/5.5/mongoose.c#L1420-L1428
  but I think having it as a flat structure is simpler. E.g. if file stream is non-NULL, then `proto_data` describes opened file. Otherwise if cgi connection is non-NULL, then `proto_data` describes opened cgi connection (a socketpair's end to the CGI program stdin/stdout). Etc etc.

<a href='https://www.codereviewhub.com/cesanta/net_skeleton/pull/45?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cesanta/net_skeleton/pull/45?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/cesanta/net_skeleton/pull/45?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/cesanta/net_skeleton/pull/45'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
