### PR TITLE
Fix websocket ping

### DIFF
--- a/modules/http.c
+++ b/modules/http.c
@@ -107,6 +107,14 @@ static int is_ws_first_fragment(unsigned char flags) {
   return (flags & 0x80) == 0 && (flags & 0x0f) != 0;
 }
 
+static void handle_incoming_websocket_frame(struct ns_connection *nc, struct websocket_message *wsm) {
+  if (wsm->flags & 0x8) {
+    nc->handler(nc, NS_WEBSOCKET_CONTROL_FRAME, wsm);
+  } else {
+    nc->handler(nc, NS_WEBSOCKET_FRAME, wsm);
+  }
+}
+
 static int deliver_websocket_data(struct ns_connection *nc) {
   /* Using unsigned char *, cause of integer arithmetic below */
   uint64_t i, data_len = 0, frame_len = 0, buf_len = nc->recv_iobuf.len,
@@ -175,12 +183,12 @@ static int deliver_websocket_data(struct ns_connection *nc) {
       if (wsm.flags & 0x80) {
         wsm.data = p + 1 + sizeof(*sizep);
         wsm.size = *sizep;
-        nc->handler(nc, NS_WEBSOCKET_FRAME, &wsm);
+        handle_incoming_websocket_frame(nc, &wsm);
         iobuf_remove(&nc->recv_iobuf, 1 + sizeof(*sizep) + *sizep);
       }
     } else {
       /* TODO(lsm): properly handle OOB control frames during defragmentation */
-      nc->handler(nc, NS_WEBSOCKET_FRAME, &wsm);          /* Call handler */
+      handle_incoming_websocket_frame(nc, &wsm);
       iobuf_remove(&nc->recv_iobuf, (size_t) frame_len);  /* Cleanup frame */
     }
   }

--- a/modules/http.h
+++ b/modules/http.h
@@ -45,6 +45,7 @@ struct websocket_message {
 #define NS_WEBSOCKET_HANDSHAKE_REQUEST  111   /* NULL */
 #define NS_WEBSOCKET_HANDSHAKE_DONE     112   /* NULL */
 #define NS_WEBSOCKET_FRAME              113   /* struct websocket_message * */
+#define NS_WEBSOCKET_CONTROL_FRAME      114   /* struct websocket_message * */
 
 void ns_set_protocol_http_websocket(struct ns_connection *);
 void ns_send_websocket_handshake(struct ns_connection *, const char *,

--- a/net_skeleton.c
+++ b/net_skeleton.c
@@ -1598,6 +1598,14 @@ static int is_ws_first_fragment(unsigned char flags) {
   return (flags & 0x80) == 0 && (flags & 0x0f) != 0;
 }
 
+static void handle_incoming_websocket_frame(struct ns_connection *nc, struct websocket_message *wsm) {
+  if (wsm->flags & 0x8) {
+    nc->handler(nc, NS_WEBSOCKET_CONTROL_FRAME, wsm);
+  } else {
+    nc->handler(nc, NS_WEBSOCKET_FRAME, wsm);
+  }
+}
+
 static int deliver_websocket_data(struct ns_connection *nc) {
   /* Using unsigned char *, cause of integer arithmetic below */
   uint64_t i, data_len = 0, frame_len = 0, buf_len = nc->recv_iobuf.len,
@@ -1666,12 +1674,12 @@ static int deliver_websocket_data(struct ns_connection *nc) {
       if (wsm.flags & 0x80) {
         wsm.data = p + 1 + sizeof(*sizep);
         wsm.size = *sizep;
-        nc->handler(nc, NS_WEBSOCKET_FRAME, &wsm);
+        handle_incoming_websocket_frame(nc, &wsm);
         iobuf_remove(&nc->recv_iobuf, 1 + sizeof(*sizep) + *sizep);
       }
     } else {
       /* TODO(lsm): properly handle OOB control frames during defragmentation */
-      nc->handler(nc, NS_WEBSOCKET_FRAME, &wsm);          /* Call handler */
+      handle_incoming_websocket_frame(nc, &wsm);
       iobuf_remove(&nc->recv_iobuf, (size_t) frame_len);  /* Cleanup frame */
     }
   }

--- a/net_skeleton.h
+++ b/net_skeleton.h
@@ -461,6 +461,7 @@ struct websocket_message {
 #define NS_WEBSOCKET_HANDSHAKE_REQUEST  111   /* NULL */
 #define NS_WEBSOCKET_HANDSHAKE_DONE     112   /* NULL */
 #define NS_WEBSOCKET_FRAME              113   /* struct websocket_message * */
+#define NS_WEBSOCKET_CONTROL_FRAME      114   /* struct websocket_message * */
 
 void ns_set_protocol_http_websocket(struct ns_connection *);
 void ns_send_websocket_handshake(struct ns_connection *, const char *,


### PR DESCRIPTION
The pong control frame was interpreted as a data frame by the chat example. I figured it might be confusing for users to filter out frames manually, but the user handler can get them as NS_WEBSOCKET_CONTROL_FRAMEs, following the general net_skeleton philosophy.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/cesanta/net_skeleton/pull/49?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/cesanta/net_skeleton/pull/49'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
