### PR TITLE
Declare CircleCI build artefacts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,9 @@
+general:
+  artifacts:
+    - "fossa.c"
+    - "fossa.h"
+    - "docs/index.html"
+
 machine:
   pre:
     - sudo pip install cpp-coveralls
@@ -14,3 +20,5 @@ checkout:
 test:
   pre:
     - make all difftest
+
+  


### PR DESCRIPTION
We don't technically need the CI system to collect our build artefacts since we keep them in the source repository itself, but can be useful in order to make it clear what are actual build artefacts.
