### PR TITLE
Add google cpplint test, enforcing a subset of rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .jig
 cscope.out
+TAGS
 

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,3 @@
+set noparent
+filter=-build,-readability,+whitespace,-whitespace/comments,-runtime/int,-runtime/references,-whitespace/parens
+linelength=80

--- a/fossa.h
+++ b/fossa.h
@@ -58,7 +58,7 @@
 #ifdef __va_copy
 #define va_copy __va_copy
 #else
-#define va_copy(x,y) (x) = (y)
+#define va_copy(x, y) (x) = (y)
 #endif
 #endif
 
@@ -121,8 +121,12 @@ typedef struct stat ns_stat_t;
 #endif /* _WIN32 */
 
 #ifdef NS_ENABLE_DEBUG
-#define DBG(x) do { printf("%-20s ", __func__); printf x; putchar('\n'); \
-  fflush(stdout); } while(0)
+#define DBG(x) do {           \
+    printf("%-20s ", __func__);                   \
+    printf x;                                     \
+    putchar('\n');                                \
+    fflush(stdout);                               \
+  } while(0)
 #else
 #define DBG(x)
 #endif
@@ -151,6 +155,8 @@ typedef struct stat ns_stat_t;
 
 #ifndef NS_IOBUF_HEADER_INCLUDED
 #define NS_IOBUF_HEADER_INCLUDED
+
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -233,8 +239,14 @@ struct ns_connection;
 typedef void (*ns_event_handler_t)(struct ns_connection *, int ev, void *);
 
 /* Events. Meaning of event parameter (evp) is given in the comment. */
-#define NS_POLL    0  /* Sent to each connection on each call to ns_mgr_poll() */
-#define NS_ACCEPT  1  /* New connection accept()-ed. union socket_address *addr */
+#define NS_POLL    0  /*
+                       * Sent to each connection on each call
+                       * to ns_mgr_poll()
+                       */
+#define NS_ACCEPT  1  /*
+                       * New connection accept()-ed.
+                       * union socket_address *addr
+                       */
 #define NS_CONNECT 2  /* connect() succeeded or failed. int *success_status */
 #define NS_RECV    3  /* Data has benn received. int *num_bytes */
 #define NS_SEND    4  /* Data has been written to a socket. int *num_bytes */
@@ -299,12 +311,13 @@ void ns_broadcast(struct ns_mgr *, ns_event_handler_t, void *, size_t);
 struct ns_connection *ns_next(struct ns_mgr *, struct ns_connection *);
 
 #define NS_COMMON_CONNECTION_OPTIONS \
-  void *user_data; \
-  unsigned int flags; \
-  char **error_string \
+  void *user_data;                   \
+  unsigned int flags;                \
+  char **error_string                \
 
 #define NS_COPY_COMMON_CONNECTION_OPTIONS(dst, src) \
-  *((struct ns_connection_common_opts*)(dst)) = *((struct ns_connection_common_opts*)(src));
+  *((struct ns_connection_common_opts*)(dst)) =     \
+    *((struct ns_connection_common_opts*)(src));
 
 struct ns_connection_common_opts {
   NS_COMMON_CONNECTION_OPTIONS;
@@ -314,19 +327,26 @@ struct ns_add_sock_opts {
   NS_COMMON_CONNECTION_OPTIONS;
 };
 struct ns_connection *ns_add_sock(struct ns_mgr *, sock_t, ns_event_handler_t);
-struct ns_connection *ns_add_sock_opt(struct ns_mgr *, sock_t, ns_event_handler_t, struct ns_add_sock_opts);
+struct ns_connection *ns_add_sock_opt(struct ns_mgr *, sock_t,
+                                      ns_event_handler_t,
+                                      struct ns_add_sock_opts);
 
 struct ns_bind_opts {
   NS_COMMON_CONNECTION_OPTIONS;
 };
-struct ns_connection *ns_bind(struct ns_mgr *, const char *, ns_event_handler_t);
-struct ns_connection *ns_bind_opt(struct ns_mgr *, const char *, ns_event_handler_t, struct ns_bind_opts);
+struct ns_connection *ns_bind(struct ns_mgr *, const char *,
+                              ns_event_handler_t);
+struct ns_connection *ns_bind_opt(struct ns_mgr *, const char *,
+                                  ns_event_handler_t, struct ns_bind_opts);
 
 struct ns_connect_opts {
   NS_COMMON_CONNECTION_OPTIONS;
 };
-struct ns_connection *ns_connect(struct ns_mgr *, const char *, ns_event_handler_t);
-struct ns_connection *ns_connect_opt(struct ns_mgr *, const char *, ns_event_handler_t, struct ns_connect_opts);
+struct ns_connection *ns_connect(struct ns_mgr *, const char *,
+                                 ns_event_handler_t);
+struct ns_connection *ns_connect_opt(struct ns_mgr *, const char *,
+                                     ns_event_handler_t,
+                                     struct ns_connect_opts);
 const char *ns_set_ssl(struct ns_connection *nc, const char *, const char *);
 
 int ns_send(struct ns_connection *, const void *buf, int len);
@@ -335,8 +355,8 @@ int ns_vprintf(struct ns_connection *, const char *fmt, va_list ap);
 
 /* Utility functions */
 void *ns_start_thread(void *(*f)(void *), void *p);
-int ns_socketpair(sock_t [2]);
-int ns_socketpair2(sock_t [2], int sock_type);  /* SOCK_STREAM or SOCK_DGRAM */
+int ns_socketpair(sock_t[2]);
+int ns_socketpair2(sock_t[2], int sock_type);  /* SOCK_STREAM or SOCK_DGRAM */
 void ns_set_close_on_exec(sock_t);
 void ns_sock_to_str(sock_t sock, char *buf, size_t len, int flags);
 int ns_hexdump(const void *buf, int len, char *dst, int dst_len);
@@ -720,7 +740,8 @@ struct ns_send_mqtt_handshake_opts {
 #define NS_MQTT_HAS_PASSWORD  0x40
 #define NS_MQTT_HAS_USER_NAME 0x80
 #define NS_MQTT_GET_WILL_QOS(flags) (((flags) & 0x18) >> 3)
-#define NS_MQTT_SET_WILL_QOS(flags, qos) (flags) = ((flags) & ~0x18) | ((qos) << 3)
+#define NS_MQTT_SET_WILL_QOS(flags, qos) (flags) = \
+      ((flags) & ~0x18) | ((qos) << 3)
 
 /* CONNACK return codes */
 #define NS_MQTT_CONNACK_ACCEPTED             0

--- a/modules/CPPLINT.cfg
+++ b/modules/CPPLINT.cfg
@@ -1,0 +1,1 @@
+exclude_files=sha1\.c

--- a/modules/common.h
+++ b/modules/common.h
@@ -58,7 +58,7 @@
 #ifdef __va_copy
 #define va_copy __va_copy
 #else
-#define va_copy(x,y) (x) = (y)
+#define va_copy(x, y) (x) = (y)
 #endif
 #endif
 
@@ -121,8 +121,12 @@ typedef struct stat ns_stat_t;
 #endif /* _WIN32 */
 
 #ifdef NS_ENABLE_DEBUG
-#define DBG(x) do { printf("%-20s ", __func__); printf x; putchar('\n'); \
-  fflush(stdout); } while(0)
+#define DBG(x) do {           \
+    printf("%-20s ", __func__);                   \
+    printf x;                                     \
+    putchar('\n');                                \
+    fflush(stdout);                               \
+  } while(0)
 #else
 #define DBG(x)
 #endif

--- a/modules/http.c
+++ b/modules/http.c
@@ -9,7 +9,7 @@
 
 #ifndef NS_DISABLE_HTTP_WEBSOCKET
 
-#include "fossa.h"
+#include "../fossa.h"
 #include "internal.h"
 
 struct proto_data_http {
@@ -202,7 +202,8 @@ struct ns_str *ns_get_http_header(struct http_message *hm, const char *name) {
 
   for (i = 0; i < ARRAY_SIZE(hm->header_names); i++) {
     struct ns_str *h = &hm->header_names[i], *v = &hm->header_values[i];
-    if (h->p != NULL && h->len == len && !ns_ncasecmp(h->p, name, len)) return v;
+    if (h->p != NULL && h->len == len && !ns_ncasecmp(h->p, name, len))
+      return v;
   }
 
   return NULL;
@@ -216,7 +217,8 @@ static int is_ws_first_fragment(unsigned char flags) {
   return (flags & 0x80) == 0 && (flags & 0x0f) != 0;
 }
 
-static void handle_incoming_websocket_frame(struct ns_connection *nc, struct websocket_message *wsm) {
+static void handle_incoming_websocket_frame(struct ns_connection *nc,
+                                            struct websocket_message *wsm) {
   if (wsm->flags & 0x8) {
     nc->handler(nc, NS_WEBSOCKET_CONTROL_FRAME, wsm);
   } else {
@@ -358,13 +360,13 @@ void ns_send_websocket_framev(struct ns_connection *nc, int op,
                               const struct ns_str *strv, int strvcnt) {
   int i;
   int len = 0;
-  for (i=0; i<strvcnt; i++) {
+  for (i = 0; i < strvcnt; i++) {
     len += strv[i].len;
   }
 
   ns_send_ws_header(nc, op, len);
 
-  for (i=0; i<strvcnt; i++) {
+  for (i = 0; i < strvcnt; i++) {
     ns_send(nc, strv[i].p, strv[i].len);
   }
 

--- a/modules/iobuf.c
+++ b/modules/iobuf.c
@@ -19,7 +19,7 @@
  * == IO Buffers
  */
 
-#include "fossa.h"
+#include "../fossa.h"
 #include "internal.h"
 
 /* Initializes an IO buffer. */

--- a/modules/iobuf.h
+++ b/modules/iobuf.h
@@ -18,6 +18,8 @@
 #ifndef NS_IOBUF_HEADER_INCLUDED
 #define NS_IOBUF_HEADER_INCLUDED
 
+#include <sys/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/modules/json-rpc.c
+++ b/modules/json-rpc.c
@@ -7,7 +7,7 @@
 
 #ifndef NS_DISABLE_JSON_RPC
 
-#include "fossa.h"
+#include "../fossa.h"
 #include "json-rpc.h"
 
 /*

--- a/modules/mqtt.c
+++ b/modules/mqtt.c
@@ -9,7 +9,7 @@
 
 #ifndef NS_DISABLE_MQTT
 
-#include "fossa.h"
+#include "../fossa.h"
 #include "internal.h"
 
 static int parse_mqtt(struct iobuf *io, struct ns_mqtt_message *mm) {
@@ -120,7 +120,9 @@ void ns_send_mqtt_handshake(struct ns_connection *nc, const char *client_id) {
   ns_send_mqtt_handshake_opt(nc, client_id, opts);
 }
 
-void ns_send_mqtt_handshake_opt(struct ns_connection *nc, const char *client_id, struct ns_send_mqtt_handshake_opts opts) {
+void ns_send_mqtt_handshake_opt(struct ns_connection *nc,
+                                const char *client_id,
+                                struct ns_send_mqtt_handshake_opts opts) {
   uint8_t header = NS_MQTT_CMD_CONNECT << 4;
   uint8_t rem_len;
   uint16_t keep_alive;
@@ -181,14 +183,14 @@ void ns_mqtt_subscribe(struct ns_connection *nc,
   uint16_t topic_len_n;
 
   size_t i;
-  for (i=0; i<topics_len; i++)
+  for (i = 0; i < topics_len; i++)
     rem_len += 2 + strlen(topics[i].topic) + 1;
 
   ns_send(nc, &header, 1);
   ns_send(nc, &rem_len, 1); /* TODO(mkm) implement variable length encoding */
   ns_send(nc, &message_id_n, 2);
 
-  for (i=0; i<topics_len; i++) {
+  for (i = 0; i < topics_len; i++) {
     topic_len_n = htons(strlen(topics[i].topic));
     ns_send(nc, &topic_len_n, 2);
     ns_send(nc, topics[i].topic, strlen(topics[i].topic));

--- a/modules/mqtt.h
+++ b/modules/mqtt.h
@@ -78,7 +78,8 @@ struct ns_send_mqtt_handshake_opts {
 #define NS_MQTT_HAS_PASSWORD  0x40
 #define NS_MQTT_HAS_USER_NAME 0x80
 #define NS_MQTT_GET_WILL_QOS(flags) (((flags) & 0x18) >> 3)
-#define NS_MQTT_SET_WILL_QOS(flags, qos) (flags) = ((flags) & ~0x18) | ((qos) << 3)
+#define NS_MQTT_SET_WILL_QOS(flags, qos) (flags) = \
+      ((flags) & ~0x18) | ((qos) << 3)
 
 /* CONNACK return codes */
 #define NS_MQTT_CONNACK_ACCEPTED             0

--- a/modules/skeleton.h
+++ b/modules/skeleton.h
@@ -56,8 +56,14 @@ struct ns_connection;
 typedef void (*ns_event_handler_t)(struct ns_connection *, int ev, void *);
 
 /* Events. Meaning of event parameter (evp) is given in the comment. */
-#define NS_POLL    0  /* Sent to each connection on each call to ns_mgr_poll() */
-#define NS_ACCEPT  1  /* New connection accept()-ed. union socket_address *addr */
+#define NS_POLL    0  /*
+                       * Sent to each connection on each call
+                       * to ns_mgr_poll()
+                       */
+#define NS_ACCEPT  1  /*
+                       * New connection accept()-ed.
+                       * union socket_address *addr
+                       */
 #define NS_CONNECT 2  /* connect() succeeded or failed. int *success_status */
 #define NS_RECV    3  /* Data has benn received. int *num_bytes */
 #define NS_SEND    4  /* Data has been written to a socket. int *num_bytes */
@@ -122,12 +128,13 @@ void ns_broadcast(struct ns_mgr *, ns_event_handler_t, void *, size_t);
 struct ns_connection *ns_next(struct ns_mgr *, struct ns_connection *);
 
 #define NS_COMMON_CONNECTION_OPTIONS \
-  void *user_data; \
-  unsigned int flags; \
-  char **error_string \
+  void *user_data;                   \
+  unsigned int flags;                \
+  char **error_string                \
 
 #define NS_COPY_COMMON_CONNECTION_OPTIONS(dst, src) \
-  *((struct ns_connection_common_opts*)(dst)) = *((struct ns_connection_common_opts*)(src));
+  *((struct ns_connection_common_opts*)(dst)) =     \
+    *((struct ns_connection_common_opts*)(src));
 
 struct ns_connection_common_opts {
   NS_COMMON_CONNECTION_OPTIONS;
@@ -137,19 +144,26 @@ struct ns_add_sock_opts {
   NS_COMMON_CONNECTION_OPTIONS;
 };
 struct ns_connection *ns_add_sock(struct ns_mgr *, sock_t, ns_event_handler_t);
-struct ns_connection *ns_add_sock_opt(struct ns_mgr *, sock_t, ns_event_handler_t, struct ns_add_sock_opts);
+struct ns_connection *ns_add_sock_opt(struct ns_mgr *, sock_t,
+                                      ns_event_handler_t,
+                                      struct ns_add_sock_opts);
 
 struct ns_bind_opts {
   NS_COMMON_CONNECTION_OPTIONS;
 };
-struct ns_connection *ns_bind(struct ns_mgr *, const char *, ns_event_handler_t);
-struct ns_connection *ns_bind_opt(struct ns_mgr *, const char *, ns_event_handler_t, struct ns_bind_opts);
+struct ns_connection *ns_bind(struct ns_mgr *, const char *,
+                              ns_event_handler_t);
+struct ns_connection *ns_bind_opt(struct ns_mgr *, const char *,
+                                  ns_event_handler_t, struct ns_bind_opts);
 
 struct ns_connect_opts {
   NS_COMMON_CONNECTION_OPTIONS;
 };
-struct ns_connection *ns_connect(struct ns_mgr *, const char *, ns_event_handler_t);
-struct ns_connection *ns_connect_opt(struct ns_mgr *, const char *, ns_event_handler_t, struct ns_connect_opts);
+struct ns_connection *ns_connect(struct ns_mgr *, const char *,
+                                 ns_event_handler_t);
+struct ns_connection *ns_connect_opt(struct ns_mgr *, const char *,
+                                     ns_event_handler_t,
+                                     struct ns_connect_opts);
 const char *ns_set_ssl(struct ns_connection *nc, const char *, const char *);
 
 int ns_send(struct ns_connection *, const void *buf, int len);
@@ -158,8 +172,8 @@ int ns_vprintf(struct ns_connection *, const char *fmt, va_list ap);
 
 /* Utility functions */
 void *ns_start_thread(void *(*f)(void *), void *p);
-int ns_socketpair(sock_t [2]);
-int ns_socketpair2(sock_t [2], int sock_type);  /* SOCK_STREAM or SOCK_DGRAM */
+int ns_socketpair(sock_t[2]);
+int ns_socketpair2(sock_t[2], int sock_type);  /* SOCK_STREAM or SOCK_DGRAM */
 void ns_set_close_on_exec(sock_t);
 void ns_sock_to_str(sock_t sock, char *buf, size_t len, int flags);
 int ns_hexdump(const void *buf, int len, char *dst, int dst_len);

--- a/modules/util.c
+++ b/modules/util.c
@@ -7,7 +7,7 @@
  * == Utilities
  */
 
-#include "fossa.h"
+#include "../fossa.h"
 #include "internal.h"
 
 /*

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,6 @@
 PROG = unit_test
 SSL=-DNS_ENABLE_SSL
-CFLAGS = -W -Wall -Werror -I.. $(SSL) -DNS_ENABLE_IPV6 -pthread -g -O0 $(CFLAGS_EXTRA)
+CFLAGS = -W -Wall -Werror $(SSL) -DNS_ENABLE_IPV6 -pthread -g -O0 $(CFLAGS_EXTRA)
 PEDANTIC=$(shell gcc --version 2>/dev/null | grep -q clang && echo -pedantic)
 AMALGAMATED_SOURCES = $(PROG).c ../fossa.c
 EAT_MALLOC_WARNINGS=MallocLogFile=/dev/null
@@ -12,7 +12,7 @@ MINGW_GCC=/usr/local/gcc-4.8.0-qt-4.8.4-for-mingw32/win32-gcc/bin/i586-mingw32-g
 
 all: clean $(PROG)_ansi $(PROG)_c99 $(PROG) $(PROG)_coverage
 
-.PHONY: clean clean_coverage lcov valgrind docker $(PROG) $(PROG)_ansi $(PROG)_c99 $(PROG)_coverage $(PROG).exe $(PROG)_mingw.exe
+.PHONY: clean clean_coverage lcov valgrind docker cpplint $(PROG) $(PROG)_ansi $(PROG)_c99 $(PROG)_coverage $(PROG).exe $(PROG)_mingw.exe
 
 $(PROG): Makefile
 	g++ -x c++ $(AMALGAMATED_SOURCES) -o $(PROG) $(CFLAGS) -lssl
@@ -27,7 +27,7 @@ $(PROG)_c99: Makefile
 	$(EAT_MALLOC_WARNINGS) ./$(PROG)_c99 $(TEST_FILTER)
 
 $(PROG)_mingw.exe: Makefile
-	$(MINGW_GCC) $(AMALGAMATED_SOURCES) -o $(PROG)_mingw.exe -W -Wall -Werror -I..
+	$(MINGW_GCC) $(AMALGAMATED_SOURCES) -o $(PROG)_mingw.exe -W -Wall -Werror
 
 $(PROG).exe:
 	wine cl $(AMALGAMATED_SOURCES) /MD /I.. /Zi $(CFLAGS_EXTRA) && echo "Compiled OK\n"
@@ -53,6 +53,9 @@ valgrind:
 #   docker run -v $(CURDIR)/../..:/cesanta -t -i --entrypoint=/bin/bash cesanta/fossa_test
 docker:
 	docker run -v $(CURDIR)/../..:/cesanta cesanta/fossa_test
+
+cpplint:
+	cpplint.py --verbose=0 --extensions=c,h ../modules/*.[ch] >/dev/null
 
 clean: clean_coverage
 	rm -rf $(PROG) $(PROG)_ansi $(PROG)_c99 $(PROG)_coverage *.txt *.exe *.obj *.o a.out *.pdb *.opt

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -15,7 +15,7 @@
  * license, as set out in <http://cesanta.com/>.
  */
 
-#include "fossa.h"
+#include "../fossa.h"
 
 #define FAIL(str, line) do {                    \
   printf("%s:%d:1 [%s]\n", __FILE__, line, str); \


### PR DESCRIPTION
Also change all includes from "fossa.h" to "../fossa.h"
so that tools like flycheck don't need special flags to find
the headers.

Fixes all style violations and excludes sha1.c which is foreign code.
Line length set to 80 cols, following the rules in the developer primer doc.

The cpplint is not yet enabled in the default tests, to minimize
dependencies needed by a random developer. It can be enabled in the CI build.
