### PR TITLE
Add 'local' includes to headers

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,7 +19,7 @@ index.html: $(ADOCS) Makefile style.css index-docinfo.html
 	  -a stylesheet=style.css \
 	  index.adoc -o index.html
 
-%.adoc: ../modules/%.c
+%.adoc: ../modules/%.c ../modules/%.h
 	$(DOCGEN) -o $@ $<
 
 index-docinfo.html: doc.js jquery.min.js Makefile

--- a/fossa.h
+++ b/fossa.h
@@ -156,7 +156,6 @@ typedef struct stat ns_stat_t;
 #ifndef NS_IOBUF_HEADER_INCLUDED
 #define NS_IOBUF_HEADER_INCLUDED
 
-#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -200,6 +199,7 @@ void iobuf_resize(struct iobuf *, size_t new_size);
 
 #ifndef NS_SKELETON_HEADER_INCLUDED
 #define NS_SKELETON_HEADER_INCLUDED
+
 
 #ifdef NS_ENABLE_SSL
 #ifdef __APPLE__
@@ -280,11 +280,11 @@ struct ns_connection {
   struct iobuf send_iobuf;    /* Data scheduled for sending */
   SSL *ssl;
   SSL_CTX *ssl_ctx;
-  time_t last_io_time;        /* Timestamp of the last socket IO */
-  ns_event_handler_t proto_handler;   /* Protocol-specific event handler */
-  void *proto_data;                   /* Protocol-specific data */
-  ns_event_handler_t handler; /* Event handler function */
-  void *user_data;            /* User-specific data */
+  time_t last_io_time;               /* Timestamp of the last socket IO */
+  ns_event_handler_t proto_handler;  /* Protocol-specific event handler */
+  void *proto_data;                  /* Protocol-specific data */
+  ns_event_handler_t handler;        /* Event handler function */
+  void *user_data;                   /* User-specific data */
 
   unsigned long flags;
 #define NSF_FINISHED_SENDING_DATA   (1 << 0)
@@ -450,6 +450,7 @@ int json_emit_va(char *buf, int buf_len, const char *fmt, va_list);
 #if !defined(NS_SHA1_HEADER_INCLUDED) && !defined(NS_DISABLE_SHA1)
 #define NS_SHA1_HEADER_INCLUDED
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -475,6 +476,7 @@ void SHA1Final(unsigned char digest[20], SHA1_CTX *);
 
 #ifndef NS_UTIL_HEADER_DEFINED
 #define NS_UTIL_HEADER_DEFINED
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -508,6 +510,7 @@ void ns_set_error_string(char **e, const char *s);
 
 #ifndef NS_HTTP_HEADER_DEFINED
 #define NS_HTTP_HEADER_DEFINED
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -683,6 +686,7 @@ int ns_rpc_dispatch(const char *buf, int, char *dst, int dst_len,
 
 #ifndef NS_MQTT_HEADER_INCLUDED
 #define NS_MQTT_HEADER_INCLUDED
+
 
 struct ns_mqtt_message {
   int cmd;

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -3,7 +3,7 @@ include modules.mk
 all: ../fossa.c ../fossa.h
 
 ../fossa.h: Makefile $(HEADERS)
-	@cat $(HEADERS) >$@
+	@cat $(HEADERS) | sed '/^#include "/d' >$@
 
 ../fossa.c: Makefile $(SOURCES)
 	@(echo '#include "fossa.h"'; cat internal.h; (cat $(SOURCES) | sed '/^#include "/d')) >$@

--- a/modules/http.h
+++ b/modules/http.h
@@ -6,6 +6,8 @@
 #ifndef NS_HTTP_HEADER_DEFINED
 #define NS_HTTP_HEADER_DEFINED
 
+#include "skeleton.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/modules/iobuf.h
+++ b/modules/iobuf.h
@@ -18,7 +18,7 @@
 #ifndef NS_IOBUF_HEADER_INCLUDED
 #define NS_IOBUF_HEADER_INCLUDED
 
-#include <sys/types.h>
+#include "common.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/mqtt.h
+++ b/modules/mqtt.h
@@ -18,6 +18,8 @@
 #ifndef NS_MQTT_HEADER_INCLUDED
 #define NS_MQTT_HEADER_INCLUDED
 
+#include "skeleton.h"
+
 struct ns_mqtt_message {
   int cmd;
   int payload_len;

--- a/modules/sha1.h
+++ b/modules/sha1.h
@@ -6,6 +6,8 @@
 #if !defined(NS_SHA1_HEADER_INCLUDED) && !defined(NS_DISABLE_SHA1)
 #define NS_SHA1_HEADER_INCLUDED
 
+#include "common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/modules/skeleton.h
+++ b/modules/skeleton.h
@@ -18,6 +18,9 @@
 #ifndef NS_SKELETON_HEADER_INCLUDED
 #define NS_SKELETON_HEADER_INCLUDED
 
+#include "common.h"
+#include "iobuf.h"
+
 #ifdef NS_ENABLE_SSL
 #ifdef __APPLE__
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -97,11 +100,11 @@ struct ns_connection {
   struct iobuf send_iobuf;    /* Data scheduled for sending */
   SSL *ssl;
   SSL_CTX *ssl_ctx;
-  time_t last_io_time;        /* Timestamp of the last socket IO */
-  ns_event_handler_t proto_handler;   /* Protocol-specific event handler */
-  void *proto_data;                   /* Protocol-specific data */
-  ns_event_handler_t handler; /* Event handler function */
-  void *user_data;            /* User-specific data */
+  time_t last_io_time;               /* Timestamp of the last socket IO */
+  ns_event_handler_t proto_handler;  /* Protocol-specific event handler */
+  void *proto_data;                  /* Protocol-specific data */
+  ns_event_handler_t handler;        /* Event handler function */
+  void *user_data;                   /* User-specific data */
 
   unsigned long flags;
 #define NSF_FINISHED_SENDING_DATA   (1 << 0)

--- a/modules/util.h
+++ b/modules/util.h
@@ -6,6 +6,8 @@
 #ifndef NS_UTIL_HEADER_DEFINED
 #define NS_UTIL_HEADER_DEFINED
 
+#include "common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */


### PR DESCRIPTION
Local headers need to be checkable for syntax in isolation
(with emacs flycheck or equivalent). This includes are then stripped away
in the amalgamated version like we did for `.c` files.
This can also be used in future to generate the correct order of amalgamation
and detect dependency cycles.

Also, fixes docs makefile to also depend on .h files,
useful now since we parse structs.
