### PR TITLE
Resurrect `test_parse_address`

### DIFF
--- a/fossa.c
+++ b/fossa.c
@@ -453,7 +453,8 @@ int ns_resolve(const char *host, char *buf, size_t n) {
 }
 
 /* Address format: [PROTO://][IP_ADDRESS:]PORT[:CERT][:CA_CERT] */
-static int ns_parse_address(const char *str, union socket_address *sa, int *p) {
+NS_INTERNAL int ns_parse_address(const char *str, union socket_address *sa,
+                               int *p) {
   unsigned int a, b, c, d, port = 0;
   int len = 0;
   char host[200];

--- a/fossa.h
+++ b/fossa.h
@@ -135,6 +135,10 @@ typedef struct stat ns_stat_t;
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 #endif
 
+#ifndef NS_INTERNAL
+#define NS_INTERNAL static
+#endif
+
 #endif /* NS_COMMON_HEADER_INCLUDED */
 /*
  * Copyright (c) 2014 Cesanta Software Limited

--- a/modules/common.h
+++ b/modules/common.h
@@ -135,4 +135,8 @@ typedef struct stat ns_stat_t;
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 #endif
 
+#ifndef NS_INTERNAL
+#define NS_INTERNAL static
+#endif
+
 #endif /* NS_COMMON_HEADER_INCLUDED */

--- a/modules/net.c
+++ b/modules/net.c
@@ -310,7 +310,8 @@ int ns_resolve(const char *host, char *buf, size_t n) {
 }
 
 /* Address format: [PROTO://][IP_ADDRESS:]PORT[:CERT][:CA_CERT] */
-static int ns_parse_address(const char *str, union socket_address *sa, int *p) {
+NS_INTERNAL int ns_parse_address(const char *str, union socket_address *sa,
+                               int *p) {
   unsigned int a, b, c, d, port = 0;
   int len = 0;
   char host[200];

--- a/scripts/docgen.py
+++ b/scripts/docgen.py
@@ -72,7 +72,7 @@ def parse_tag(src, pos):
         return parse_struct(src, pos)
 
 def parse_function(src, pos):
-    m = re.match(r"(static)?.*?(\w*)\(", src)
+    m = re.match(r"(NS_INTERNAL|static)?.*?(\w*)\(", src)
     if not m:
         print >>sys.stderr, "cannot parse function decl", src
         return None

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,6 @@
 PROG = unit_test
 SSL=-DNS_ENABLE_SSL
-CFLAGS = -W -Wall -Werror $(SSL) -DNS_ENABLE_IPV6 -pthread -g -O0 $(CFLAGS_EXTRA)
+CFLAGS = -W -Wall -Werror $(SSL) -DNS_ENABLE_IPV6 -DNS_INTERNAL="" -pthread -g -O0 $(CFLAGS_EXTRA)
 PEDANTIC=$(shell gcc --version 2>/dev/null | grep -q clang && echo -pedantic)
 AMALGAMATED_SOURCES = $(PROG).c ../fossa.c
 EAT_MALLOC_WARNINGS=MallocLogFile=/dev/null


### PR DESCRIPTION
Tentative solution for testing static functions without including the `.c` file
