### PR TITLE
Add ns_disconnect, an `alltest` make target.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .jig
 cscope.out
 TAGS
-
+*.dSYM

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ all: $(SUBDIRS)
 $(SUBDIRS): %:
 	@$(MAKE) -C $@
 
+# full test suite, requiring more dependencies on the dev's machine
+alltests: all
+	@$(MAKE) -C test docker valgrind cpplint
+
 difftest:
 	@TMP=`mktemp -t checkout-diff.XXXXXX`; \
 	git diff docs/index.html fossa.c fossa.h >$$TMP ; \

--- a/fossa.c
+++ b/fossa.c
@@ -3381,4 +3381,9 @@ void ns_mqtt_pong(struct ns_connection *nc) {
   ns_mqtt_prepend_header(nc, NS_MQTT_CMD_PINGRESP, 0, 0);
 }
 
+/* Send a DISCONNECT command. */
+void ns_mqtt_disconnect(struct ns_connection *nc) {
+  ns_mqtt_prepend_header(nc, NS_MQTT_CMD_DISCONNECT, 0, 0);
+}
+
 #endif  /* NS_DISABLE_MQTT */

--- a/fossa.h
+++ b/fossa.h
@@ -729,6 +729,7 @@ struct ns_send_mqtt_handshake_opts {
 #define NS_MQTT_CMD_UNSUBACK    11
 #define NS_MQTT_CMD_PINGREQ     12
 #define NS_MQTT_CMD_PINGRESP    13
+#define NS_MQTT_CMD_DISCONNECT  14
 
 /* MQTT event types */
 #define NS_MQTT_EVENT_BASE  200
@@ -745,6 +746,7 @@ struct ns_send_mqtt_handshake_opts {
 #define NS_MQTT_UNSUBACK    (NS_MQTT_EVENT_BASE + NS_MQTT_CMD_UNSUBACK)
 #define NS_MQTT_PINGREQ     (NS_MQTT_EVENT_BASE + NS_MQTT_CMD_PINGREQ)
 #define NS_MQTT_PINGRESP    (NS_MQTT_EVENT_BASE + NS_MQTT_CMD_PINGRESP)
+#define NS_MQTT_DISCONNECT  (NS_MQTT_EVENT_BASE + NS_MQTT_CMD_DISCONNECT)
 
 /* Message flags */
 #define NS_MQTT_RETAIN 0x1
@@ -788,8 +790,8 @@ void ns_mqtt_subscribe(struct ns_connection *,
                        uint16_t);
 void ns_mqtt_unsubscribe(struct ns_connection *, char **, size_t,
                          uint16_t);
-
 void ns_mqtt_ping(struct ns_connection *);
+void ns_mqtt_disconnect(struct ns_connection *);
 
 /* replies */
 void ns_mqtt_connack(struct ns_connection *, uint8_t);

--- a/modules/mqtt.c
+++ b/modules/mqtt.c
@@ -304,4 +304,9 @@ void ns_mqtt_pong(struct ns_connection *nc) {
   ns_mqtt_prepend_header(nc, NS_MQTT_CMD_PINGRESP, 0, 0);
 }
 
+/* Send a DISCONNECT command. */
+void ns_mqtt_disconnect(struct ns_connection *nc) {
+  ns_mqtt_prepend_header(nc, NS_MQTT_CMD_DISCONNECT, 0, 0);
+}
+
 #endif  /* NS_DISABLE_MQTT */

--- a/modules/mqtt.h
+++ b/modules/mqtt.h
@@ -57,6 +57,7 @@ struct ns_send_mqtt_handshake_opts {
 #define NS_MQTT_CMD_UNSUBACK    11
 #define NS_MQTT_CMD_PINGREQ     12
 #define NS_MQTT_CMD_PINGRESP    13
+#define NS_MQTT_CMD_DISCONNECT  14
 
 /* MQTT event types */
 #define NS_MQTT_EVENT_BASE  200
@@ -73,6 +74,7 @@ struct ns_send_mqtt_handshake_opts {
 #define NS_MQTT_UNSUBACK    (NS_MQTT_EVENT_BASE + NS_MQTT_CMD_UNSUBACK)
 #define NS_MQTT_PINGREQ     (NS_MQTT_EVENT_BASE + NS_MQTT_CMD_PINGREQ)
 #define NS_MQTT_PINGRESP    (NS_MQTT_EVENT_BASE + NS_MQTT_CMD_PINGRESP)
+#define NS_MQTT_DISCONNECT  (NS_MQTT_EVENT_BASE + NS_MQTT_CMD_DISCONNECT)
 
 /* Message flags */
 #define NS_MQTT_RETAIN 0x1
@@ -116,8 +118,8 @@ void ns_mqtt_subscribe(struct ns_connection *,
                        uint16_t);
 void ns_mqtt_unsubscribe(struct ns_connection *, char **, size_t,
                          uint16_t);
-
 void ns_mqtt_ping(struct ns_connection *);
+void ns_mqtt_disconnect(struct ns_connection *);
 
 /* replies */
 void ns_mqtt_connack(struct ns_connection *, uint8_t);

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -892,7 +892,7 @@ static const char *test_mqtt_simple_acks(void) {
   return NULL;
 }
 
-static const char *test_mqtt_ping(void) {
+static const char *test_mqtt_nullary(void) {
   unsigned long i;
   struct {
     uint8_t cmd;
@@ -900,6 +900,7 @@ static const char *test_mqtt_ping(void) {
   } cases[] = {
     {NS_MQTT_CMD_PINGREQ, ns_mqtt_ping},
     {NS_MQTT_CMD_PINGRESP, ns_mqtt_pong},
+    {NS_MQTT_CMD_DISCONNECT, ns_mqtt_disconnect},
   };
 
   for (i = 0; i < ARRAY_SIZE(cases); i++) {
@@ -1282,7 +1283,7 @@ static const char *run_tests(const char *filter) {
   RUN_TEST(test_mqtt_connack);
   RUN_TEST(test_mqtt_suback);
   RUN_TEST(test_mqtt_simple_acks);
-  RUN_TEST(test_mqtt_ping);
+  RUN_TEST(test_mqtt_nullary);
   RUN_TEST(test_mqtt_parse_mqtt);
 #ifndef NO_DNS_TEST
   RUN_TEST(test_resolve);


### PR DESCRIPTION
Reword the test case name for testing the encoding of a bunch of simple cmds.

`ns_disconnect` is the last mqtt cmd to be defined.
