### PR TITLE
Remove iobuf_prepend and add iobuf_insert instead

### DIFF
--- a/fossa.c
+++ b/fossa.c
@@ -92,51 +92,35 @@ void iobuf_free(struct iobuf *iobuf) {
  * It returns the amount of bytes appended.
  */
 size_t iobuf_append(struct iobuf *io, const void *buf, size_t len) {
-  char *p = NULL;
-
-  assert(io != NULL);
-  assert(io->len <= io->size);
-
-  if (io->len + len <= io->size) {
-    memcpy(io->buf + io->len, buf, len);
-    io->len += len;
-  } else if ((p = (char *) NS_REALLOC(io->buf, io->len + len)) != NULL) {
-    io->buf = p;
-    memcpy(io->buf + io->len, buf, len);
-    io->len += len;
-    io->size = io->len;
-  } else {
-    len = 0;
-  }
-
-  return len;
+  return iobuf_insert(io, io->len, buf, len);
 }
 
 /*
- * Inserts data at the beginning of the IO buffer
+ * Inserts data at a specified offset in the IO buffer.
  *
  * Existing data will be shifted forwards and the buffer will
  * be grown if necessary.
- * It returns the amount of bytes prepended.
+ * It returns the amount of bytes inserted.
  */
-size_t iobuf_prepend(struct iobuf *io, const void *buf, size_t len) {
+size_t iobuf_insert(struct iobuf *io, size_t off, const void *buf, size_t len) {
   char *p = NULL;
 
   assert(io != NULL);
   assert(io->len <= io->size);
+  assert(off <= io->len);
 
   /* check overflow */
   if (~(size_t)0 - (size_t)io->buf < len)
     return 0;
 
   if (io->len + len <= io->size) {
-    memmove(io->buf + len, io->buf, io->len);
-    memcpy(io->buf, buf, len);
+    memmove(io->buf + off + len, io->buf + off, io->len - off);
+    memcpy(io->buf + off, buf, len);
     io->len += len;
   } else if ((p = (char *) NS_REALLOC(io->buf, io->len + len)) != NULL) {
     io->buf = p;
-    memmove(io->buf + len, io->buf, io->len);
-    memcpy(io->buf, buf, len);
+    memmove(io->buf + off + len, io->buf + off, io->len - off);
+    memcpy(io->buf + off, buf, len);
     io->len += len;
     io->size = io->len;
   } else {
@@ -3445,10 +3429,13 @@ void ns_send_mqtt_handshake_opt(struct ns_connection *nc,
 
 static void ns_mqtt_prepend_header(struct ns_connection *nc, uint8_t cmd,
                                    uint8_t flags, size_t len) {
+  size_t off = nc->send_iobuf.len - len;
   uint8_t header = cmd << 4 | (uint8_t)flags;
 
   uint8_t buf[1 + sizeof(size_t)];
   uint8_t *vlen = &buf[1];
+
+  assert(nc->send_iobuf.len >= len);
 
   buf[0] = header;
 
@@ -3461,7 +3448,7 @@ static void ns_mqtt_prepend_header(struct ns_connection *nc, uint8_t cmd,
     vlen++;
   } while (len > 0);
 
-  iobuf_prepend(&nc->send_iobuf, buf, vlen - buf);
+  iobuf_insert(&nc->send_iobuf, off, buf, vlen - buf);
 }
 
 /* Publish a message to a given channel. */
@@ -3720,7 +3707,7 @@ void ns_send_dns_query(struct ns_connection* nc, const char *name,
   /* TCP DNS requires messages to be prefixed with len */
   if (!(nc->flags & NSF_UDP)) {
     uint16_t len = htons(pkt.len);
-    iobuf_prepend(&pkt, &len, 2);
+    iobuf_insert(&pkt, 0, &len, 2);
   }
 
   ns_send(nc, pkt.buf, pkt.len);

--- a/fossa.h
+++ b/fossa.h
@@ -175,7 +175,7 @@ struct iobuf {
 void iobuf_init(struct iobuf *, size_t initial_size);
 void iobuf_free(struct iobuf *);
 size_t iobuf_append(struct iobuf *, const void *data, size_t data_size);
-size_t iobuf_prepend(struct iobuf *, const void *data, size_t data_size);
+size_t iobuf_insert(struct iobuf *, size_t, const void *, size_t);
 void iobuf_remove(struct iobuf *, size_t data_size);
 void iobuf_resize(struct iobuf *, size_t new_size);
 

--- a/modules/dns.c
+++ b/modules/dns.c
@@ -120,7 +120,7 @@ void ns_send_dns_query(struct ns_connection* nc, const char *name,
   /* TCP DNS requires messages to be prefixed with len */
   if (!(nc->flags & NSF_UDP)) {
     uint16_t len = htons(pkt.len);
-    iobuf_prepend(&pkt, &len, 2);
+    iobuf_insert(&pkt, 0, &len, 2);
   }
 
   ns_send(nc, pkt.buf, pkt.len);

--- a/modules/iobuf.c
+++ b/modules/iobuf.c
@@ -42,51 +42,35 @@ void iobuf_free(struct iobuf *iobuf) {
  * It returns the amount of bytes appended.
  */
 size_t iobuf_append(struct iobuf *io, const void *buf, size_t len) {
-  char *p = NULL;
-
-  assert(io != NULL);
-  assert(io->len <= io->size);
-
-  if (io->len + len <= io->size) {
-    memcpy(io->buf + io->len, buf, len);
-    io->len += len;
-  } else if ((p = (char *) NS_REALLOC(io->buf, io->len + len)) != NULL) {
-    io->buf = p;
-    memcpy(io->buf + io->len, buf, len);
-    io->len += len;
-    io->size = io->len;
-  } else {
-    len = 0;
-  }
-
-  return len;
+  return iobuf_insert(io, io->len, buf, len);
 }
 
 /*
- * Inserts data at the beginning of the IO buffer
+ * Inserts data at a specified offset in the IO buffer.
  *
  * Existing data will be shifted forwards and the buffer will
  * be grown if necessary.
- * It returns the amount of bytes prepended.
+ * It returns the amount of bytes inserted.
  */
-size_t iobuf_prepend(struct iobuf *io, const void *buf, size_t len) {
+size_t iobuf_insert(struct iobuf *io, size_t off, const void *buf, size_t len) {
   char *p = NULL;
 
   assert(io != NULL);
   assert(io->len <= io->size);
+  assert(off <= io->len);
 
   /* check overflow */
   if (~(size_t)0 - (size_t)io->buf < len)
     return 0;
 
   if (io->len + len <= io->size) {
-    memmove(io->buf + len, io->buf, io->len);
-    memcpy(io->buf, buf, len);
+    memmove(io->buf + off + len, io->buf + off, io->len - off);
+    memcpy(io->buf + off, buf, len);
     io->len += len;
   } else if ((p = (char *) NS_REALLOC(io->buf, io->len + len)) != NULL) {
     io->buf = p;
-    memmove(io->buf + len, io->buf, io->len);
-    memcpy(io->buf, buf, len);
+    memmove(io->buf + off + len, io->buf + off, io->len - off);
+    memcpy(io->buf + off, buf, len);
     io->len += len;
     io->size = io->len;
   } else {

--- a/modules/iobuf.h
+++ b/modules/iobuf.h
@@ -34,7 +34,7 @@ struct iobuf {
 void iobuf_init(struct iobuf *, size_t initial_size);
 void iobuf_free(struct iobuf *);
 size_t iobuf_append(struct iobuf *, const void *data, size_t data_size);
-size_t iobuf_prepend(struct iobuf *, const void *data, size_t data_size);
+size_t iobuf_insert(struct iobuf *, size_t, const void *, size_t);
 void iobuf_remove(struct iobuf *, size_t data_size);
 void iobuf_resize(struct iobuf *, size_t new_size);
 

--- a/modules/mqtt.c
+++ b/modules/mqtt.c
@@ -153,10 +153,13 @@ void ns_send_mqtt_handshake_opt(struct ns_connection *nc,
 
 static void ns_mqtt_prepend_header(struct ns_connection *nc, uint8_t cmd,
                                    uint8_t flags, size_t len) {
+  size_t off = nc->send_iobuf.len - len;
   uint8_t header = cmd << 4 | (uint8_t)flags;
 
   uint8_t buf[1 + sizeof(size_t)];
   uint8_t *vlen = &buf[1];
+
+  assert(nc->send_iobuf.len >= len);
 
   buf[0] = header;
 
@@ -169,7 +172,7 @@ static void ns_mqtt_prepend_header(struct ns_connection *nc, uint8_t cmd,
     vlen++;
   } while (len > 0);
 
-  iobuf_prepend(&nc->send_iobuf, buf, vlen - buf);
+  iobuf_insert(&nc->send_iobuf, off, buf, vlen - buf);
 }
 
 /* Publish a message to a given channel. */

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -83,17 +83,23 @@ static const char *test_iobuf(void) {
   ASSERT(io.size == 10);
   ASSERT(io.len == strlen(data));
 
-  ASSERT(iobuf_prepend(&io, prefix, strlen(prefix)) == strlen(prefix));
+  ASSERT(iobuf_insert(&io, 0, prefix, strlen(prefix)) == strlen(prefix));
   ASSERT(io.size == 10);
   ASSERT(io.len == strlen(data) + strlen(prefix));
 
-  ASSERT(iobuf_prepend(&io, big_prefix, strlen(big_prefix)) == strlen(big_prefix));
+  ASSERT(iobuf_insert(&io, 0, big_prefix, strlen(big_prefix)) == strlen(big_prefix));
   ASSERT(io.size == strlen(big_prefix) + strlen(prefix) + strlen(data));
+  ASSERT(strncmp(io.buf, "Some long prefix: MYTEST", 24) == 0);
+
+  ASSERT(iobuf_insert(&io, strlen(big_prefix), data, strlen(data)) == strlen(data));
+  ASSERT(io.size == strlen(big_prefix) + strlen(data) + strlen(prefix) + strlen(data));
+  ASSERT(strncmp(io.buf, "Some long prefix: TESTMYTEST", 28) == 0);
+
+  /* test allocation failure */
+  ASSERT(iobuf_insert(&io, 0, NULL, 1125899906842624) == 0);
 
   /* test overflow */
-  ASSERT(iobuf_prepend(&io, NULL, -1) == 0);
-  /* test allocation failure */
-  ASSERT(iobuf_prepend(&io, NULL, 1125899906842624) == 0);
+  ASSERT(iobuf_insert(&io, 0, NULL, -1) == 0);
   iobuf_free(&io);
   return NULL;
 }


### PR DESCRIPTION
Absolute prepend is basically useless the buffer is completely consumed
until the next time it's needed (e.g. UDP).

This fixes sending multiple MQTT commands through the same TCP connection.
