### PR TITLE
Add ASAN target and clang to Docker image

### DIFF
--- a/fossa.c
+++ b/fossa.c
@@ -4219,7 +4219,7 @@ static int ns_get_ip_address_of_nameserver(char *name, size_t name_len) {
     /* Try to figure out what nameserver to use */
     for (ret--; fgets(line, sizeof(line), fp) != NULL; ) {
       char buf[256];
-      if (sscanf(line, "nameserver %256[^\n]s", buf) == 1) {
+      if (sscanf(line, "nameserver %255[^\n]s", buf) == 1) {
         snprintf(name, name_len, "udp://%s:53", buf);
         ret++;
         break;

--- a/modules/resolv.c
+++ b/modules/resolv.c
@@ -74,7 +74,7 @@ static int ns_get_ip_address_of_nameserver(char *name, size_t name_len) {
     /* Try to figure out what nameserver to use */
     for (ret--; fgets(line, sizeof(line), fp) != NULL; ) {
       char buf[256];
-      if (sscanf(line, "nameserver %256[^\n]s", buf) == 1) {
+      if (sscanf(line, "nameserver %255[^\n]s", buf) == 1) {
         snprintf(name, name_len, "udp://%s:53", buf);
         ret++;
         break;

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -3,6 +3,7 @@ unit_test_ansi
 unit_test_c99
 unit_test_coverage
 unit_test_valgrind
+unit_test_asan
 *.gcov
 *.gcno
 *.gcda

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:trusty
 MAINTAINER Marko Mikulicic <mkm@cesanta.com>
 
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential libssl-dev
+RUN apt-get install -y --no-install-recommends clang-3.5
 
 VOLUME ['/cesanta']
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,6 +5,15 @@ PEDANTIC=$(shell gcc --version 2>/dev/null | grep -q clang && echo -pedantic)
 AMALGAMATED_SOURCES = $(PROG).c ../fossa.c
 EAT_MALLOC_WARNINGS=MallocLogFile=/dev/null
 
+CLANG:=clang
+
+# OSX clang doesn't build ASAN. Use brew:
+#  $ brew tap homebrew/versions
+#  $ brew install llvm35 --with-clang --with-asan
+ifneq ("$(wildcard /usr/local/bin/clang-3.5)","")
+	CLANG:=/usr/local/bin/clang-3.5
+endif
+
 include ../modules/modules.mk
 
 # http://crossgcc.rts-software.org/doku.php?id=compiling_for_win32
@@ -58,11 +67,15 @@ valgrind-leak:
 docker:
 	docker run --rm -v $(CURDIR)/../..:/cesanta cesanta/fossa_test
 
+asan:
+	$(CLANG) -fsanitize=address -fcolor-diagnostics -std=c99 $(PROG).c $(addprefix ../modules/, $(SOURCES)) -o $(PROG)_asan $(CFLAGS) -DNO_DNS_TEST -UNS_ENABLE_SSL
+	ASAN_SYMBOLIZER_PATH=/usr/local/bin/llvm-symbolizer-3.5 ASAN_OPTIONS=allocator_may_return_null=1,symbolize=1 ./$(PROG)_asan
+
 cpplint:
 	cpplint.py --verbose=0 --extensions=c,h ../modules/*.[ch] >/dev/null
 
 clean: clean_coverage
-	rm -rf $(PROG) $(PROG)_ansi $(PROG)_c99 $(PROG)_coverage *.txt *.exe *.obj *.o a.out *.pdb *.opt
+	rm -rf $(PROG) $(PROG)_ansi $(PROG)_c99 $(PROG)_coverage $(PROG)_asan *.txt *.exe *.obj *.o a.out *.pdb *.opt
 
 clean_coverage:
 	rm -rf *.gc* *.dSYM index.html


### PR DESCRIPTION
LLVM AddressSanitizer can detect a different set of things
than valgrind, for example stack OOB access.

Fixed one issue caught with ASAN.
