### PR TITLE
Refactor and improve test Makefile

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,7 +1,8 @@
-unit_test
+unit_test_cxx
 unit_test_ansi
 unit_test_c99
-unit_test_coverage
+unit_test_c11
+unit_test_gcov
 unit_test_valgrind
 unit_test_asan
 *.gcov

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,39 +1,17 @@
 PROG = unit_test
+MODULES_DIR=../modules
 SSL=-DNS_ENABLE_SSL
 CFLAGS = -W -Wall -Werror $(SSL) -DNS_ENABLE_IPV6 -DNS_ENABLE_THREADS -DNS_ENABLE_MQTT_BROKER -DNS_INTERNAL="" -DNS_MODULE_LINES -include unit_test.h -DNS_MALLOC=test_malloc -DNS_CALLOC=test_calloc -pthread -g -O0 $(CFLAGS_EXTRA)
-PEDANTIC=$(shell gcc --version 2>/dev/null | grep -q clang && echo -pedantic)
-AMALGAMATED_SOURCES = $(PROG).c ../fossa.c
-EAT_MALLOC_WARNINGS=MallocLogFile=/dev/null
+LDFLAGS=-lssl
+AMALGAMATED_SOURCES = ../fossa.c
 
-CLANG:=clang
-
-# OSX clang doesn't build ASAN. Use brew:
-#  $ brew tap homebrew/versions
-#  $ brew install llvm35 --with-clang --with-asan
-ifneq ("$(wildcard /usr/local/bin/clang-3.5)","")
-	CLANG:=/usr/local/bin/clang-3.5
-endif
-
-include ../modules/modules.mk
+include test.mk
+include $(MODULES_DIR)/modules.mk
 
 # http://crossgcc.rts-software.org/doku.php?id=compiling_for_win32
 MINGW_GCC=/usr/local/gcc-4.8.0-qt-4.8.4-for-mingw32/win32-gcc/bin/i586-mingw32-gcc
 
-all: clean $(PROG)_ansi $(PROG)_c99 $(PROG) $(PROG)_coverage
-
-.PHONY: clean clean_coverage lcov valgrind docker cpplint $(PROG) $(PROG)_ansi $(PROG)_c99 $(PROG)_coverage $(PROG).exe $(PROG)_mingw.exe
-
-$(PROG): Makefile
-	g++ -x c++ $(AMALGAMATED_SOURCES) -o $(PROG) $(CFLAGS) -lssl
-	$(EAT_MALLOC_WARNINGS) ./$(PROG) $(TEST_FILTER)
-
-$(PROG)_ansi: Makefile
-	gcc $(PEDANTIC) -ansi $(AMALGAMATED_SOURCES) -o $(PROG)_ansi $(CFLAGS) -lssl
-	$(EAT_MALLOC_WARNINGS) ./$(PROG)_ansi $(TEST_FILTER)
-
-$(PROG)_c99: Makefile
-	gcc $(PEDANTIC) -std=c99 $(AMALGAMATED_SOURCES) -o $(PROG)_c99 $(CFLAGS) -lssl
-	$(EAT_MALLOC_WARNINGS) ./$(PROG)_c99 $(TEST_FILTER)
+.PHONY: $(PROG).exe $(PROG)_mingw.exe
 
 $(PROG)_mingw.exe: Makefile
 	$(MINGW_GCC) $(AMALGAMATED_SOURCES) -o $(PROG)_mingw.exe -W -Wall -Werror
@@ -44,38 +22,7 @@ $(PROG).exe:
 win: $(PROG).exe
 	wine $(PROG).exe
 
-$(PROG)_coverage: Makefile
-	$(MAKE) clean_coverage
-	gcc $(PEDANTIC) -std=c99 -fprofile-arcs -ftest-coverage $(PROG).c $(addprefix ../modules/, $(SOURCES)) -o $(PROG)_coverage $(CFLAGS) -lssl
-	$(EAT_MALLOC_WARNINGS) ./$(PROG)_coverage $(TEST_FILTER)
-	gcov -p $(PROG).c $(notdir $(SOURCES)) >/dev/null
-
-lcov: clean $(PROG)_coverage
-	lcov -o lcov.info -c -d .
-	genhtml -o lcov lcov.info
-
-valgrind:
-	gcc $(PEDANTIC) -std=c99 $(PROG).c $(addprefix ../modules/, $(SOURCES)) -o $(PROG)_valgrind $(CFLAGS) -DNO_DNS_TEST -UNS_ENABLE_SSL -lssl
-	valgrind ./unit_test_valgrind $(TEST_FILTER)
-
-valgrind-leak:
-	gcc $(PEDANTIC) -std=c99 $(PROG).c $(addprefix ../modules/, $(SOURCES)) -o $(PROG)_valgrind $(CFLAGS) -DNO_DNS_TEST -UNS_ENABLE_SSL -lssl
-	valgrind --leak-check=full ./unit_test_valgrind $(TEST_FILTER)
-
 # Interactive:
 #   docker run -v $(CURDIR)/../..:/cesanta -t -i --entrypoint=/bin/bash cesanta/fossa_test
 docker:
 	docker run --rm -v $(CURDIR)/../..:/cesanta cesanta/fossa_test
-
-asan:
-	$(CLANG) -fsanitize=address -fcolor-diagnostics -std=c99 $(PROG).c $(addprefix ../modules/, $(SOURCES)) -o $(PROG)_asan $(CFLAGS) -DNO_DNS_TEST -UNS_ENABLE_SSL
-	ASAN_SYMBOLIZER_PATH=/usr/local/bin/llvm-symbolizer-3.5 ASAN_OPTIONS=allocator_may_return_null=1,symbolize=1 ./$(PROG)_asan
-
-cpplint:
-	cpplint.py --verbose=0 --extensions=c,h ../modules/*.[ch] >/dev/null
-
-clean: clean_coverage
-	rm -rf $(PROG) $(PROG)_ansi $(PROG)_c99 $(PROG)_coverage $(PROG)_asan *.txt *.exe *.obj *.o a.out *.pdb *.opt
-
-clean_coverage:
-	rm -rf *.gc* *.dSYM index.html

--- a/test/test.mk
+++ b/test/test.mk
@@ -1,0 +1,129 @@
+# Copyright (c) 2014 Cesanta Software Limited
+# All rights reserved
+#
+# = Requires:
+#
+# - MODULES_DIR = path to directory with source files
+# - AMALGAMATED_SOURCES = path to amalgamated C file(s)
+# - PROG = name of main unit test source file
+#
+# - CFLAGS = default compiler flags
+# - LDFLAGS = default linker flags
+#
+# = Parameters:
+#
+# - V=1 -> show commandlines of executed commands
+# - TEST_FILTER -> test name (substring match)
+# - CMD -> run wrapped in cmd (e.g. make test_cxx CMD=lldb)
+#
+# = Useful targets
+#
+# - compile:   perform a very fast syntax check for all dialects
+# - presubmit: suggested presubmit tests
+# - cpplint:   run the linter
+# - lcov:      generate coverage HTML in test/lcov/index.html
+# - test_asan: run with AddressSanitizer
+# - test_valgrind: run with valgrind
+
+CLANG:=clang
+
+# OSX clang doesn't build ASAN. Use brew:
+#  $ brew tap homebrew/versions
+#  $ brew install llvm35 --with-clang --with-asan
+ifneq ("$(wildcard /usr/local/bin/clang-3.5)","")
+	CLANG:=/usr/local/bin/clang-3.5
+endif
+
+PEDANTIC=$(shell gcc --version 2>/dev/null | grep -q clang && echo -pedantic)
+
+###
+
+DIALECTS=cxx ansi c99 c11
+SPECIALS=asan gcov valgrind
+
+# Each test target might require either a different compiler name
+# a compiler flag, or a wrapper to be invoked before executing the test
+# they can be overriden here with <VAR>_<target>
+#
+# Vars are:
+# - CC: compiler
+# - CFLAGS: flags passed to the compiler, useful to set dialect and to disable incompatible tests
+# - LDFLAGS: flags passed to the compiler only when linking (e.g. not in syntax only)
+# - SOURCES: non-test source files. To be overriden if needs to build on non amalgamated files
+# - CMD: command wrapper or env variables required to run the test binary
+
+CMD=MallocLogFile=/dev/null
+
+CC_cxx=$(CXX)
+CFLAGS_cxx=-x c++
+
+CFLAGS_ansi=$(PEDANTIC) -ansi
+CFLAGS_c99=$(PEDANTIC) -std=c99
+
+CFLAGS_gcov=$(PEDANTIC) -std=c99 -fprofile-arcs -ftest-coverage
+SOURCES_gcov=$(addprefix $(MODULES_DIR)/, $(SOURCES))
+
+CC_asan=$(CLANG)
+CFLAGS_asan=-fsanitize=address -fcolor-diagnostics -std=c99 -DNO_DNS_TEST -UNS_ENABLE_SSL
+CMD_asan=ASAN_SYMBOLIZER_PATH=/usr/local/bin/llvm-symbolizer-3.5 ASAN_OPTIONS=allocator_may_return_null=1,symbolize=1 $(CMD)
+
+CMD_valgrind=valgrind
+
+###
+
+SHELL := /bin/bash
+
+SUFFIXES=$(DIALECTS) $(SPECIALS)
+
+ALL_PROGS=$(foreach p,$(SUFFIXES),$(PROG)-$(p))
+ALL_TESTS=$(foreach p,$(SUFFIXES),test_$(p))
+SHORT_TESTS=$(foreach p,$(DIALECTS),test_$(p))
+
+all: clean compile $(SHORT_TESTS)
+alltests: $(ALL_TESTS) lcov cpplint
+
+# currently both valgrind and asan tests are failing for some test cases
+# it's still useful to be able to run asan/valgrind on some specific test cases
+# but we don't enforce them for presubmit until they are stable again.
+presubmit: $(SHORT_TESTS) cpplint
+
+.PHONY: clean clean_coverage lcov valgrind docker cpplint
+ifneq ($(V), 1)
+.SILENT: $(ALL_PROGS) $(ALL_TESTS)
+endif
+
+compile:
+	@make -j8 $(foreach p,$(DIALECTS),$(PROG)-$(p)) CFLAGS_EXTRA=-fsyntax-only LDFLAGS=
+
+# HACK: cannot have two underscores
+$(PROG)-%: Makefile $(PROG).c $(or $(SOURCES_$*), $(AMALGAMATED_SOURCES))
+	@echo -e "CC\t$(PROG)_$*"
+	$(or $(CC_$*), $(CC)) $(CFLAGS_$*) $(PROG).c $(or $(SOURCES_$*), $(AMALGAMATED_SOURCES)) -o $(PROG)_$* $(CFLAGS) $(LDFLAGS)
+
+$(ALL_TESTS): test_%: Makefile $(PROG)-%
+	@echo -e "RUN\t$(PROG)_$* $(TEST_FILTER)"
+	@$(or $(CMD_$*), $(CMD)) ./$(PROG)_$* $(TEST_FILTER)
+
+coverage: Makefile clean_coverage test_gcov
+	@echo -e "RUN\tGCOV"
+	@gcov -p $(PROG).c $(notdir $(SOURCES)) >/dev/null
+
+test_leaks: Makefile
+	$(MAKE) test_valgrind CMD_valgrind="$(CMD_valgrind) --leak-check=full"
+
+lcov: clean coverage
+	@echo -e "RUN\tlcov"
+	@lcov -q -o lcov.info -c -d . 2>/dev/null
+	@genhtml -q -o lcov lcov.info
+
+cpplint:
+	@echo -e "RUN\tcpplint"
+	@cpplint.py --verbose=0 --extensions=c,h $(MODULES_DIR)/*.[ch] 2>&1 >/dev/null| grep -v "Done processing" | grep -v "file excluded by"
+
+clean: clean_coverage
+	@echo -e "CLEAN\tall"
+	@rm -rf $(PROG) $(PROG)_ansi $(PROG)_c99 $(PROG)_gcov $(PROG)_asan $(PROG)_cxx $(PROG)_valgrind lcov.info *.txt *.exe *.obj *.o a.out *.pdb *.opt
+
+clean_coverage:
+	@echo -e "CLEAN\tcoverage"
+	@rm -rf *.gc* *.dSYM index.html


### PR DESCRIPTION
Removes duplication and cleanup output.
This greatly simplifies the reusing of this makefile from
other Cesanta C projects.

Added `compile` target which performs a blazingly fast parallel syntax only
check for multiple dialects. As the tests take longer and longer, it's becoming
frustrating to figure out that there were a syntax violation in one dialect
after 30 seconds have passed.
