### PR TITLE
Added NS_DNS_MESSAGE ns_set_protocol_dns()

### DIFF
--- a/examples/captive_dns_server/.gitignore
+++ b/examples/captive_dns_server/.gitignore
@@ -1,1 +1,1 @@
-dns
+captive_dns_server

--- a/examples/captive_dns_server/Makefile
+++ b/examples/captive_dns_server/Makefile
@@ -1,3 +1,3 @@
-PROG = dns
+PROG = captive_dns_server
 
 include ../rules.mk

--- a/fossa.c
+++ b/fossa.c
@@ -4303,6 +4303,44 @@ size_t ns_dns_uncompress_name(struct ns_dns_message *msg, struct ns_str *name,
   return dst - old_dst;
 }
 
+static void dns_handler(struct ns_connection *nc, int ev, void *ev_data) {
+  struct iobuf *io = &nc->recv_iobuf;
+  struct ns_dns_message msg;
+
+  /* Pass low-level events to the user handler */
+  nc->handler(nc, ev, ev_data);
+
+  switch (ev) {
+    case NS_RECV:
+      if (ns_parse_dns(nc->recv_iobuf.buf, nc->recv_iobuf.len, &msg) == -1) {
+        /* reply + recursion allowed + format error */
+        msg.flags |= 0x8081;
+        ns_dns_insert_header(io, 0, &msg);
+        ns_send(nc, io->buf, io->len);
+      } else {
+        /* Call user handler with parsed message */
+        nc->handler(nc, NS_DNS_MESSAGE, &msg);
+      }
+      iobuf_remove(io, io->len);
+      break;
+  }
+}
+
+/*
+ * Attach built-in DNS event handler to the given listening connection.
+ *
+ * DNS event handler parses incoming UDP packets, treating them as DNS
+ * requests. If incoming packet gets successfully parsed by the DNS event
+ * handler, a user event handler will receive `NS_DNS_REQUEST` event, with
+ * `ev_data` pointing to the parsed `struct ns_dns_message`.
+ *
+ * See https://github.com/cesanta/fossa/tree/master/examples/captive_dns_server[captive_dns_server]
+ * example on how to handle DNS request and send DNS reply.
+ */
+void ns_set_protocol_dns(struct ns_connection *nc) {
+  nc->proto_handler = dns_handler;
+}
+
 #endif  /* NS_DISABLE_DNS */
 #ifdef NS_MODULE_LINES
 #line 1 "modules/resolv.c"

--- a/fossa.h
+++ b/fossa.h
@@ -897,6 +897,8 @@ extern "C" {
 #define NS_MAX_DNS_QUESTIONS 32
 #define NS_MAX_DNS_ANSWERS   32
 
+#define NS_DNS_MESSAGE      100   /* High-level DNS message event */
+
 enum ns_dns_resource_record_kind {
   NS_DNS_INVALID_RECORD = 0,
   NS_DNS_QUESTION,
@@ -939,6 +941,7 @@ int ns_parse_dns(const char *, int, struct ns_dns_message *);
 
 size_t ns_dns_uncompress_name(struct ns_dns_message *, struct ns_str *,
                               char *, int);
+void ns_set_protocol_dns(struct ns_connection *);
 
 #ifdef __cplusplus
 }

--- a/modules/dns.h
+++ b/modules/dns.h
@@ -20,6 +20,8 @@ extern "C" {
 #define NS_MAX_DNS_QUESTIONS 32
 #define NS_MAX_DNS_ANSWERS   32
 
+#define NS_DNS_MESSAGE      100   /* High-level DNS message event */
+
 enum ns_dns_resource_record_kind {
   NS_DNS_INVALID_RECORD = 0,
   NS_DNS_QUESTION,
@@ -62,6 +64,7 @@ int ns_parse_dns(const char *, int, struct ns_dns_message *);
 
 size_t ns_dns_uncompress_name(struct ns_dns_message *, struct ns_str *,
                               char *, int);
+void ns_set_protocol_dns(struct ns_connection *);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Slightly refactored captive DNS server example to use `NS_DNS_MESSAGE` event
