### PR TITLE
Fix error C4700 compiling with Visual C++

### DIFF
--- a/fossa.c
+++ b/fossa.c
@@ -572,6 +572,7 @@ NS_INTERNAL void ns_parse_address(struct ns_mgr *mgr, const char *str,
     snprintf(host, sizeof(host), "0.0.0.0");
   } else {
     union socket_address sa;
+    memset(&sa, 0, sizeof(sa));
     cb(mgr, 0, sa, ctx->proto, data);
     ns_set_error_string(error_string, "cannot parse address");
     return;
@@ -579,6 +580,7 @@ NS_INTERNAL void ns_parse_address(struct ns_mgr *mgr, const char *str,
 
   if (ctx->port >= 0xffff || str[ctx->len] != '\0') {
     union socket_address sa;
+    memset(&sa, 0, sizeof(sa));
     cb(mgr, 0, sa, ctx->proto, data);
     ns_set_error_string(error_string, "cannot parse address");
     return;


### PR DESCRIPTION
With Visual C++ 2012, error C4700 is issued when compiled with either /Od(default in Debug mode) or /Ox:
fossa.c(575): error 4700: local variable 'sa' used without having been initialized.
fossa.c(582): error 4700: local variable 'sa' used without having been initialized.

make an explicit zero memory operation as my solution.
