### PR TITLE
Add MSBuild project file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 cscope.out
 TAGS
 *.dSYM
+Debug

--- a/fossa.h
+++ b/fossa.h
@@ -90,6 +90,7 @@ typedef unsigned short uint16_t;
 typedef unsigned __int64 uint64_t;
 typedef __int64   int64_t;
 typedef SOCKET sock_t;
+typedef uint32_t in_addr_t;
 #ifdef __MINGW32__
 typedef struct stat ns_stat_t;
 #else

--- a/fossa.proj
+++ b/fossa.proj
@@ -1,0 +1,31 @@
+<Project DefaultTargets="Build" xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <ItemGroup>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>NS_ENABLE_THREADS;NS_ENABLE_MQTT_BROKER;NS_ENABLE_DNS_SERVER;NS_INTERNAL=;DNS_MODULE_LINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.default.props" />
+  <PropertyGroup>
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ItemGroup>
+    <ClCompile Include="fossa.c" />
+    <ClCompile Include="test\unit_test.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="fossa.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Targets" />
+</Project>

--- a/modules/common.h
+++ b/modules/common.h
@@ -90,6 +90,7 @@ typedef unsigned short uint16_t;
 typedef unsigned __int64 uint64_t;
 typedef __int64   int64_t;
 typedef SOCKET sock_t;
+typedef uint32_t in_addr_t;
 #ifdef __MINGW32__
 typedef struct stat ns_stat_t;
 #else

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -21,9 +21,7 @@
 #include "../modules/resolv-internal.h"
 #include "unit_test.h"
 
-#if defined ( WIN32 )
-#define __func__ __FUNCTION__
-#elif __STDC_VERSION__ < 199901L
+#if __STDC_VERSION__ < 199901L && !defined ( WIN32 )
 #define __func__ "unknown_function"
 #endif
 
@@ -1432,7 +1430,7 @@ static const char *test_hexdump_file(void) {
    * indeed it prints 0x0 on apple.
    */
   nc->user_data = (void *)0xbeef;
-  truncate(path, 0);
+  close(open(path, O_TRUNC | O_WRONLY));
 
   iobuf_append(&nc->send_iobuf, "foo", 3);
   iobuf_append(&nc->recv_iobuf, "bar", 3);
@@ -1551,7 +1549,7 @@ static const char *test_dns_decode(void) {
   const char *hostname = "go.cesanta.com";
   const char *cname = "ghs.googlehosted.com";
   struct ns_dns_resource_record *r;
-  uint16_t small;
+  uint16_t tiny;
   struct in_addr ina;
   int n;
 
@@ -1595,7 +1593,7 @@ static const char *test_dns_decode(void) {
   ASSERT(ns_dns_uncompress_name(&msg, &r->name, name, sizeof(name))
          == strlen(cname));
   ASSERT(strncmp(name, cname, strlen(cname)) == 0);
-  ASSERT(ns_dns_parse_record_data(&msg, r, &small, sizeof(small)) == -1);
+  ASSERT(ns_dns_parse_record_data(&msg, r, &tiny, sizeof(tiny)) == -1);
   ASSERT(ns_dns_parse_record_data(&msg, r, &ina, sizeof(ina)) == 0);
   ASSERT(ina.s_addr == inet_addr("74.125.136.121"));
 


### PR DESCRIPTION
Intended to be used by a windows CI system like http://www.appveyor.com/

Also fixed a few recent things that broke the windows build.
TIL: windows has '#define small char', no in_addr_t and no truncate() function.
