### PR TITLE
Allow whitespace and comments in /etc/resolv.conf & expose MD5 stuff to c++

### DIFF
--- a/examples/coap_server/coap_server.c
+++ b/examples/coap_server/coap_server.c
@@ -69,4 +69,5 @@ int main() {
   printf("Exiting on signal %d\n", s_sig_received);
 
   ns_mgr_free(&mgr);
+  return 0;
 }

--- a/fossa.c
+++ b/fossa.c
@@ -6372,7 +6372,7 @@ static int ns_get_ip_address_of_nameserver(char *name, size_t name_len) {
     /* Try to figure out what nameserver to use */
     for (ret = -1; fgets(line, sizeof(line), fp) != NULL;) {
       char buf[256];
-      if (sscanf(line, "nameserver %255[^\n]s", buf) == 1) {
+      if (sscanf(line, "nameserver %255[^\n\t #]s", buf) == 1) {
         snprintf(name, name_len, "udp://%s:53", buf);
         ret = 0;
         break;

--- a/src/md5.h
+++ b/src/md5.h
@@ -6,6 +6,10 @@
 #ifndef MD5_HEADER_DEFINED
 #define MD5_HEADER_DEFINED
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 typedef struct MD5Context {
   uint32_t buf[4];
   uint32_t bits[2];
@@ -15,5 +19,8 @@ typedef struct MD5Context {
 void MD5_Init(MD5_CTX *c);
 void MD5_Update(MD5_CTX *c, const unsigned char *data, size_t len);
 void MD5_Final(unsigned char *md, MD5_CTX *c);
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif

--- a/src/resolv.c
+++ b/src/resolv.c
@@ -86,7 +86,7 @@ static int ns_get_ip_address_of_nameserver(char *name, size_t name_len) {
     /* Try to figure out what nameserver to use */
     for (ret = -1; fgets(line, sizeof(line), fp) != NULL;) {
       char buf[256];
-      if (sscanf(line, "nameserver %255[^\n]s", buf) == 1) {
+      if (sscanf(line, "nameserver %255[^\n\t #]s", buf) == 1) {
         snprintf(name, name_len, "udp://%s:53", buf);
         ret = 0;
         break;


### PR DESCRIPTION
FIX: now its possible to have whitespace and comments after the ip address in /etc/resolv.conf
FIX: expose MD5 functions to c++
FIX: removed a warning in one of the example programs

I'm sorry this is a new pull request - I managed to rebase my baster branch, but I just don't know how to strip off commits in an open pull request...

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/fossa/285)
<!-- Reviewable:end -->
