### PR TITLE
Easy file download using ns_http_connect()

### DIFF
--- a/examples/coap_client/coap_client.c
+++ b/examples/coap_client/coap_client.c
@@ -67,4 +67,5 @@ int main(int argc, char* argv[]) {
   }
 
   ns_mgr_free(&mgr);
+	return 0;
 }

--- a/examples/http_client/http_client.c
+++ b/examples/http_client/http_client.c
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
     exit(EXIT_FAILURE);
   }
 
-  ns_connect_http(&mgr, ev_handler, argv[i], NULL, NULL);
+  ns_connect_http(&mgr, ev_handler, argv[i], NULL, NULL, NULL);
 
   while (s_exit_flag == 0) {
     ns_mgr_poll(&mgr, 1000);

--- a/examples/netcat/nc.c
+++ b/examples/netcat/nc.c
@@ -30,12 +30,12 @@ static void signal_handler(int sig_num) {
 static void show_usage_and_exit(const char *prog_name) {
   fprintf(stderr, "%s\n", "Copyright (c) 2014 CESANTA SOFTWARE");
   fprintf(stderr, "%s\n", "Usage:");
-  fprintf(stderr, "  %s\n [-d debug_file] [-l] [tcp|ssl]://[ip:]port[:cert][:ca_cert]",
+  fprintf(stderr, "  %s [-d debug_file] [-l] [tcp|ssl]://[ip:]port[:cert][:ca_cert]\n",
           prog_name);
   fprintf(stderr, "%s\n", "Examples:");
-  fprintf(stderr, "  %s\n -d hexdump.txt ssl://google.com:443", prog_name);
-  fprintf(stderr, "  %s\n -l ssl://443:ssl_cert.pem", prog_name);
-  fprintf(stderr, "  %s\n -l tcp://8080", prog_name);
+  fprintf(stderr, "  %s -d hexdump.txt ssl://google.com:443\n", prog_name);
+  fprintf(stderr, "  %s -l ssl://443:ssl_cert.pem\n", prog_name);
+  fprintf(stderr, "  %s -l tcp://8080\n\n", prog_name);
   exit(EXIT_FAILURE);
 }
 

--- a/fossa.c
+++ b/fossa.c
@@ -1937,7 +1937,7 @@ int json_emit(char *buf, int buf_len, const char *fmt, ...) {
 #ifndef NS_DISABLE_HTTP_WEBSOCKET
 
 
-enum http_proto_data_type { DATA_FILE, DATA_PUT, DATA_CGI };
+enum http_proto_data_type { DATA_FILE, DATA_PUT, DATA_CGI, DATA_FILE_DOWNLOAD };
 
 struct proto_data_http {
   FILE *fp;     /* Opened file. */
@@ -2478,6 +2478,19 @@ static void transfer_file_data(struct ns_connection *nc) {
     if (n == 0 || dp->sent >= dp->cl) {
       free_http_proto_data(nc);
     }
+  } else if (dp->type == DATA_FILE_DOWNLOAD) {
+    struct iobuf *io = &nc->recv_iobuf;
+    size_t to_write =
+        left <= 0 ? 0 : left < (int64_t) io->len ? (size_t) left : io->len;
+
+    size_t n = fwrite(io->buf, 1, to_write, dp->fp);
+    if (n > 0) {
+      iobuf_remove(io, n);
+      dp->sent += n;
+    }
+    if (dp->sent >= dp->cl) {
+      free_http_proto_data(nc);
+    }
   } else if (dp->type == DATA_CGI) {
     /* This is POST data that needs to be forwarded to the CGI process */
     if (dp->cgi_nc != NULL) {
@@ -2488,12 +2501,26 @@ static void transfer_file_data(struct ns_connection *nc) {
   }
 }
 
+static void http_download_handler(struct ns_connection *nc, int ev, void *ev_data) {
+  if (nc->proto_data != NULL )
+  {
+    transfer_file_data(nc);
+
+    if(nc->proto_data==NULL) {
+      nc->handler(nc, NS_CLOSE, NULL);
+    }
+  }
+
+  nc->handler(nc, ev, ev_data);
+  
+}
+
 static void http_handler(struct ns_connection *nc, int ev, void *ev_data) {
   struct iobuf *io = &nc->recv_iobuf;
   struct http_message hm;
   struct ns_str *vec;
   int req_len;
-
+  struct proto_data_http *dp=NULL;
   /*
    * For HTTP messages without Content-Length, always send HTTP message
    * before NS_CLOSE message.
@@ -2507,7 +2534,10 @@ static void http_handler(struct ns_connection *nc, int ev, void *ev_data) {
   }
 
   if (nc->proto_data != NULL) {
-    transfer_file_data(nc);
+    dp = (struct proto_data_http *)nc->proto_data;
+    if(dp->cl>0) {
+      transfer_file_data(nc);
+    }
   }
 
   nc->handler(nc, ev, ev_data);
@@ -2518,6 +2548,13 @@ static void http_handler(struct ns_connection *nc, int ev, void *ev_data) {
       nc->flags |= NSF_CLOSE_IMMEDIATELY;
     } else if (req_len == 0) {
       /* Do nothing, request is not yet fully buffered */
+    } else if (nc->listener == NULL && dp!=NULL && dp->type==DATA_FILE_DOWNLOAD ) {
+      /* OK we got the header and switch to a special file download handler */
+      dp->cl = hm.message.len - req_len;
+      nc->proto_handler = http_download_handler;
+      nc->handler(nc, NS_HTTP_REPLY, &hm);
+      iobuf_remove(io, req_len);
+      http_download_handler(nc, NS_RECV, ev_data);
     } else if (nc->listener == NULL &&
                ns_get_http_header(&hm, "Sec-WebSocket-Accept")) {
       /* We're websocket client, got handshake response from server. */
@@ -4260,22 +4297,27 @@ void ns_serve_http(struct ns_connection *nc, struct http_message *hm,
  * Helper function that creates outbound HTTP connection.
  *
  * If `post_data` is NULL, then GET request is created. Otherwise, POST request
- * is created with the specified POST data. Examples:
+ * is created with the specified POST data.
+ * If `save_to_file` is path to a writeable file, the body of the HTTP response is written to that file.
+ * Examples:
  *
  * [source,c]
  * ----
  *   nc1 = ns_connect_http(mgr, ev_handler_1, "http://www.google.com", NULL,
- *                         NULL);
- *   nc2 = ns_connect_http(mgr, ev_handler_1, "https://github.com", NULL, NULL);
+ *                         NULL, NULL);
+ *   nc2 = ns_connect_http(mgr, ev_handler_1, "https://github.com", NULL, NULL, NULL);
  *   nc3 = ns_connect_http(mgr, ev_handler_1, "my_server:8000/form_submit/",
- *                         NULL, "var_1=value_1&var_2=value_2");
+ *                         NULL, "var_1=value_1&var_2=value_2", NULL);
+ *   nc4 = ns_connect_http(mgr, ev_handler_1, "my_server:8000/a_nice_picture.png",
+ *                         NULL, NULL, "a_nice_picture.png");
  * ----
  */
 struct ns_connection *ns_connect_http(struct ns_mgr *mgr,
                                       ns_event_handler_t ev_handler,
                                       const char *url,
                                       const char *extra_headers,
-                                      const char *post_data) {
+                                      const char *post_data,
+                                      const char *save_to_file ) {
   struct ns_connection *nc;
   char addr[1100], path[4096]; /* NOTE: keep sizes in sync with sscanf below */
   int use_ssl = 0;
@@ -4299,6 +4341,26 @@ struct ns_connection *ns_connect_http(struct ns_mgr *mgr,
   }
 
   if ((nc = ns_connect(mgr, addr, ev_handler)) != NULL) {
+    if( save_to_file ) {
+      struct proto_data_http *dp;
+
+      if ((dp = (struct proto_data_http *) NS_CALLOC(1, sizeof(*dp))) == NULL) {
+        fprintf(stderr,"TODO: HANDLE THIS horrible error!\n");
+        return NULL;
+      } else if ((dp->fp = fopen(save_to_file, "wp")) == NULL) {
+        fprintf(stderr,"ERROR: cannot open %s for writing\n",save_to_file);
+        NS_FREE(dp);
+        nc->proto_data = NULL;
+        return NULL;
+      } else {
+        dp->type = DATA_FILE_DOWNLOAD;
+        dp->cl = -1;
+        dp->sent = 0;
+        dp->cgi_nc = NULL;
+        nc->proto_data = dp;
+      }
+    }
+
     ns_set_protocol_http_websocket(nc);
 
     if (use_ssl) {

--- a/fossa.h
+++ b/fossa.h
@@ -670,7 +670,7 @@ int ns_http_create_digest_auth_header(char *buf, size_t buf_len,
                                       const char *auth_domain, const char *user,
                                       const char *passwd);
 struct ns_connection *ns_connect_http(struct ns_mgr *, ns_event_handler_t,
-                                      const char *, const char *, const char *);
+                                      const char *, const char *, const char *, const char *);
 
 /*
  * This structure defines how `ns_serve_http()` works.

--- a/src/http.c
+++ b/src/http.c
@@ -11,7 +11,7 @@
 
 #include "internal.h"
 
-enum http_proto_data_type { DATA_FILE, DATA_PUT, DATA_CGI };
+enum http_proto_data_type { DATA_FILE, DATA_PUT, DATA_CGI, DATA_FILE_DOWNLOAD };
 
 struct proto_data_http {
   FILE *fp;     /* Opened file. */
@@ -552,6 +552,19 @@ static void transfer_file_data(struct ns_connection *nc) {
     if (n == 0 || dp->sent >= dp->cl) {
       free_http_proto_data(nc);
     }
+  } else if (dp->type == DATA_FILE_DOWNLOAD) {
+    struct iobuf *io = &nc->recv_iobuf;
+    size_t to_write =
+        left <= 0 ? 0 : left < (int64_t) io->len ? (size_t) left : io->len;
+
+    size_t n = fwrite(io->buf, 1, to_write, dp->fp);
+    if (n > 0) {
+      iobuf_remove(io, n);
+      dp->sent += n;
+    }
+    if (dp->sent >= dp->cl) {
+      free_http_proto_data(nc);
+    }
   } else if (dp->type == DATA_CGI) {
     /* This is POST data that needs to be forwarded to the CGI process */
     if (dp->cgi_nc != NULL) {
@@ -562,12 +575,26 @@ static void transfer_file_data(struct ns_connection *nc) {
   }
 }
 
+static void http_download_handler(struct ns_connection *nc, int ev, void *ev_data) {
+  if (nc->proto_data != NULL )
+  {
+    transfer_file_data(nc);
+
+    if(nc->proto_data==NULL) {
+      nc->handler(nc, NS_CLOSE, NULL);
+    }
+  }
+
+  nc->handler(nc, ev, ev_data);
+  
+}
+
 static void http_handler(struct ns_connection *nc, int ev, void *ev_data) {
   struct iobuf *io = &nc->recv_iobuf;
   struct http_message hm;
   struct ns_str *vec;
   int req_len;
-
+  struct proto_data_http *dp=NULL;
   /*
    * For HTTP messages without Content-Length, always send HTTP message
    * before NS_CLOSE message.
@@ -581,7 +608,10 @@ static void http_handler(struct ns_connection *nc, int ev, void *ev_data) {
   }
 
   if (nc->proto_data != NULL) {
-    transfer_file_data(nc);
+    dp = (struct proto_data_http *)nc->proto_data;
+    if(dp->cl>0) {
+      transfer_file_data(nc);
+    }
   }
 
   nc->handler(nc, ev, ev_data);
@@ -592,6 +622,13 @@ static void http_handler(struct ns_connection *nc, int ev, void *ev_data) {
       nc->flags |= NSF_CLOSE_IMMEDIATELY;
     } else if (req_len == 0) {
       /* Do nothing, request is not yet fully buffered */
+    } else if (nc->listener == NULL && dp!=NULL && dp->type==DATA_FILE_DOWNLOAD ) {
+      /* OK we got the header and switch to a special file download handler */
+      dp->cl = hm.message.len - req_len;
+      nc->proto_handler = http_download_handler;
+      nc->handler(nc, NS_HTTP_REPLY, &hm);
+      iobuf_remove(io, req_len);
+      http_download_handler(nc, NS_RECV, ev_data);
     } else if (nc->listener == NULL &&
                ns_get_http_header(&hm, "Sec-WebSocket-Accept")) {
       /* We're websocket client, got handshake response from server. */
@@ -2334,22 +2371,27 @@ void ns_serve_http(struct ns_connection *nc, struct http_message *hm,
  * Helper function that creates outbound HTTP connection.
  *
  * If `post_data` is NULL, then GET request is created. Otherwise, POST request
- * is created with the specified POST data. Examples:
+ * is created with the specified POST data.
+ * If `save_to_file` is path to a writeable file, the body of the HTTP response is written to that file.
+ * Examples:
  *
  * [source,c]
  * ----
  *   nc1 = ns_connect_http(mgr, ev_handler_1, "http://www.google.com", NULL,
- *                         NULL);
- *   nc2 = ns_connect_http(mgr, ev_handler_1, "https://github.com", NULL, NULL);
+ *                         NULL, NULL);
+ *   nc2 = ns_connect_http(mgr, ev_handler_1, "https://github.com", NULL, NULL, NULL);
  *   nc3 = ns_connect_http(mgr, ev_handler_1, "my_server:8000/form_submit/",
- *                         NULL, "var_1=value_1&var_2=value_2");
+ *                         NULL, "var_1=value_1&var_2=value_2", NULL);
+ *   nc4 = ns_connect_http(mgr, ev_handler_1, "my_server:8000/a_nice_picture.png",
+ *                         NULL, NULL, "a_nice_picture.png");
  * ----
  */
 struct ns_connection *ns_connect_http(struct ns_mgr *mgr,
                                       ns_event_handler_t ev_handler,
                                       const char *url,
                                       const char *extra_headers,
-                                      const char *post_data) {
+                                      const char *post_data,
+                                      const char *save_to_file ) {
   struct ns_connection *nc;
   char addr[1100], path[4096]; /* NOTE: keep sizes in sync with sscanf below */
   int use_ssl = 0;
@@ -2373,6 +2415,26 @@ struct ns_connection *ns_connect_http(struct ns_mgr *mgr,
   }
 
   if ((nc = ns_connect(mgr, addr, ev_handler)) != NULL) {
+    if( save_to_file ) {
+      struct proto_data_http *dp;
+
+      if ((dp = (struct proto_data_http *) NS_CALLOC(1, sizeof(*dp))) == NULL) {
+        fprintf(stderr,"TODO: HANDLE THIS horrible error!\n");
+        return NULL;
+      } else if ((dp->fp = fopen(save_to_file, "wp")) == NULL) {
+        fprintf(stderr,"ERROR: cannot open %s for writing\n",save_to_file);
+        NS_FREE(dp);
+        nc->proto_data = NULL;
+        return NULL;
+      } else {
+        dp->type = DATA_FILE_DOWNLOAD;
+        dp->cl = -1;
+        dp->sent = 0;
+        dp->cgi_nc = NULL;
+        nc->proto_data = dp;
+      }
+    }
+
     ns_set_protocol_http_websocket(nc);
 
     if (use_ssl) {

--- a/src/http.h
+++ b/src/http.h
@@ -114,7 +114,7 @@ int ns_http_create_digest_auth_header(char *buf, size_t buf_len,
                                       const char *auth_domain, const char *user,
                                       const char *passwd);
 struct ns_connection *ns_connect_http(struct ns_mgr *, ns_event_handler_t,
-                                      const char *, const char *, const char *);
+                                      const char *, const char *, const char *, const char *);
 
 /*
  * This structure defines how `ns_serve_http()` works.


### PR DESCRIPTION
This is the new feature I tried to sneak in before ;-).
Now in a separate pull request with a single commit:

- ns_connect_http() can be passed the path to a file where the http body is supposed to be written to
- updated documentation
- added unit tests

I can understand this change of the interface might need some discussion.
Feel free to contact me.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/fossa/288)
<!-- Reviewable:end -->
